### PR TITLE
feat(layout): 共通レイアウト作成（ヘッダー・フッター）

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,17 @@
+// 管理画面用レイアウト
+// TODO: NextAuth設定後に管理者ロールチェックを実装する
+import type { ReactNode } from 'react'
+import { AdminHeader } from '@/components/layouts/AdminHeader'
+
+type Props = {
+  children: ReactNode
+}
+
+export default function AdminLayout({ children }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AdminHeader />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  )
+}

--- a/src/app/(shop)/layout.tsx
+++ b/src/app/(shop)/layout.tsx
@@ -1,0 +1,28 @@
+// ストアフロント用レイアウト
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { Header } from '@/components/layouts/Header'
+import { Footer } from '@/components/layouts/Footer'
+
+// ルートレイアウトのtitle templateを引き継ぐ
+export const metadata: Metadata = {
+  title: {
+    default: 'SampleShop',
+    template: '%s | SampleShop',
+  },
+  description: '上質なアイテムをお届けするオンラインショップ',
+}
+
+type Props = {
+  children: ReactNode
+}
+
+export default function ShopLayout({ children }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/layouts/AdminHeader.tsx
+++ b/src/components/layouts/AdminHeader.tsx
@@ -1,0 +1,42 @@
+// 管理画面用ヘッダー（Server Component）
+import Link from 'next/link'
+import { LayoutDashboard } from 'lucide-react'
+
+export const AdminHeader = () => {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        {/* 管理画面タイトル */}
+        <div className="flex items-center gap-2">
+          <LayoutDashboard size={24} className="text-primary" />
+          <span className="text-xl font-bold tracking-tight">管理画面</span>
+        </div>
+
+        {/* ナビゲーション */}
+        <nav
+          className="flex items-center gap-4 sm:gap-6"
+          aria-label="管理画面ナビゲーション"
+        >
+          <Link
+            href="/admin/dashboard"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ダッシュボード
+          </Link>
+          <Link
+            href="/admin/products"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            商品管理
+          </Link>
+          <Link
+            href="/admin/orders"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            注文管理
+          </Link>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -1,0 +1,42 @@
+// ストアフロント用フッター（Server Component）
+import Link from 'next/link'
+
+export const Footer = () => {
+  return (
+    <footer className="border-t bg-background">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+          {/* コピーライト */}
+          <p className="text-sm text-muted-foreground">
+            © 2024 SampleShop
+          </p>
+
+          {/* リンク群 */}
+          <nav
+            className="flex flex-wrap justify-center gap-4 sm:justify-end"
+            aria-label="フッターナビゲーション"
+          >
+            <Link
+              href="/terms"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              利用規約
+            </Link>
+            <Link
+              href="/privacy"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              プライバシーポリシー
+            </Link>
+            <Link
+              href="/contact"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              お問い合わせ
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+// ストアフロント用ヘッダー（Client Component）
+import { useState } from 'react'
+import Link from 'next/link'
+import { ShoppingBag, ShoppingCart, Menu, X } from 'lucide-react'
+
+export const Header = () => {
+  // モバイルメニューの開閉状態
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        {/* ロゴ */}
+        <Link
+          href="/"
+          className="flex items-center gap-2"
+          aria-label="SampleShop ホームへ"
+        >
+          <ShoppingBag size={24} className="text-primary" />
+          <span className="text-xl font-bold tracking-tight">SampleShop</span>
+        </Link>
+
+        {/* デスクトップナビゲーション */}
+        <nav
+          className="hidden items-center gap-6 md:flex"
+          aria-label="メインナビゲーション"
+        >
+          <Link
+            href="/products"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            商品一覧
+          </Link>
+          <Link
+            href="/wishlist"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ウィッシュリスト
+          </Link>
+        </nav>
+
+        {/* デスクトップアクション */}
+        <div className="hidden items-center gap-4 md:flex">
+          <Link
+            href="/cart"
+            aria-label="カートを見る"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ShoppingCart size={24} />
+          </Link>
+          <Link
+            href="/login"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ログイン
+          </Link>
+        </div>
+
+        {/* モバイルメニューボタン */}
+        <button
+          className="p-2 text-muted-foreground transition-colors hover:text-foreground md:hidden"
+          onClick={() => setIsMenuOpen(!isMenuOpen)}
+          aria-label={isMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+          aria-expanded={isMenuOpen}
+        >
+          {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
+        </button>
+      </div>
+
+      {/* モバイルメニュー */}
+      {isMenuOpen && (
+        <div className="border-t bg-background md:hidden">
+          <nav
+            className="flex flex-col gap-4 px-4 py-4"
+            aria-label="モバイルナビゲーション"
+          >
+            <Link
+              href="/products"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              商品一覧
+            </Link>
+            <Link
+              href="/wishlist"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              ウィッシュリスト
+            </Link>
+            <Link
+              href="/cart"
+              className="flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              <ShoppingCart size={20} />
+              カート
+            </Link>
+            <Link
+              href="/login"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              ログイン
+            </Link>
+          </nav>
+        </div>
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
## 概要
Issue #6 の実装。ストアフロント・管理画面の共通レイアウトコンポーネント作成。

## 変更内容

### 新規追加
- `src/components/layouts/Header.tsx`: ストアフロント用ヘッダー（Client Component）
  - ロゴ（ShoppingBag アイコン + "SampleShop"）
  - ナビゲーション（商品一覧・ウィッシュリスト）
  - カートアイコン・ログインリンク
  - モバイル用ハンバーガーメニュー
- `src/components/layouts/Footer.tsx`: ストアフロント用フッター（Server Component）
  - コピーライト・利用規約・プライバシーポリシー・お問い合わせ
- `src/components/layouts/AdminHeader.tsx`: 管理画面用ヘッダー（Server Component）
  - ダッシュボード・商品管理・注文管理ナビ
- `src/app/(shop)/layout.tsx`: ストアフロントレイアウト
- `src/app/(admin)/layout.tsx`: 管理画面レイアウト（認証チェックは TODO）

Closes #6