### PR TITLE
feat(cart): カート機能実装（Zustand・localStorage永続化）

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-dom": "^18",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.5.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@18.3.28)(react@18.3.1)
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -2989,6 +2992,24 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -4246,8 +4267,8 @@ snapshots:
       '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4266,7 +4287,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4277,22 +4298,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4303,7 +4324,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5966,3 +5987,8 @@ snapshots:
       graphmatch: 1.1.1
 
   zod@4.3.6: {}
+
+  zustand@5.0.12(@types/react@18.3.28)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.28
+      react: 18.3.1

--- a/src/app/(shop)/cart/loading.tsx
+++ b/src/app/(shop)/cart/loading.tsx
@@ -1,0 +1,32 @@
+// カートページ ローディングUI（スケルトン）
+export default function CartLoading() {
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      {/* タイトルスケルトン */}
+      <div className="mb-8 h-8 w-24 animate-pulse rounded-md bg-muted" />
+
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        {/* カートアイテムスケルトン */}
+        <div className="lg:col-span-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-4 border-b py-4">
+              <div className="h-24 w-24 flex-shrink-0 animate-pulse rounded-md bg-muted" />
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+                <div className="h-7 w-28 animate-pulse rounded bg-muted" />
+              </div>
+              <div className="flex flex-col items-end gap-2">
+                <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+                <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* サマリースケルトン */}
+        <div className="h-64 animate-pulse rounded-lg bg-muted" />
+      </div>
+    </main>
+  )
+}

--- a/src/app/(shop)/cart/loading.tsx
+++ b/src/app/(shop)/cart/loading.tsx
@@ -1,4 +1,6 @@
 // カートページ ローディングUI（スケルトン）
+import { CART_SKELETON_COUNT } from '@/constants/cart' // 追加
+
 export default function CartLoading() {
   return (
     <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -8,7 +10,7 @@ export default function CartLoading() {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         {/* カートアイテムスケルトン */}
         <div className="lg:col-span-2">
-          {[1, 2, 3].map((i) => (
+          {Array.from({ length: CART_SKELETON_COUNT }, (_, i) => i).map((i) => ( // 変更: 定数化
             <div key={i} className="flex items-center gap-4 border-b py-4">
               <div className="h-24 w-24 flex-shrink-0 animate-pulse rounded-md bg-muted" />
               <div className="flex flex-1 flex-col gap-2">

--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 // カートページ（Client Component）
+import { useEffect, useState } from 'react' // 追加
 import { CartEmpty } from '@/components/features/cart/CartEmpty'
 import { CartItem } from '@/components/features/cart/CartItem'
 import { CartSummary } from '@/components/features/cart/CartSummary'
@@ -8,6 +9,26 @@ import { useCartStore } from '@/stores/cartStore'
 
 export default function CartPage() {
   const { items, totalItems, totalPrice } = useCartStore()
+  // 変更: SSRハイドレーション不一致を防ぐためマウント後に表示する
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    useCartStore.persist.rehydrate()
+    setMounted(true)
+  }, [])
+
+  // ハイドレーション前はローディング状態を返す
+  if (!mounted) {
+    return (
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <h1 className="mb-8 text-2xl font-bold tracking-tight">カート</h1>
+        <div className="animate-pulse space-y-4" aria-label="読み込み中">
+          <div className="h-24 rounded-lg bg-muted" />
+          <div className="h-24 rounded-lg bg-muted" />
+        </div>
+      </main>
+    )
+  }
 
   return (
     <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">

--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+// カートページ（Client Component）
+import { CartEmpty } from '@/components/features/cart/CartEmpty'
+import { CartItem } from '@/components/features/cart/CartItem'
+import { CartSummary } from '@/components/features/cart/CartSummary'
+import { useCartStore } from '@/stores/cartStore'
+
+export default function CartPage() {
+  const { items, totalItems, totalPrice } = useCartStore()
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="mb-8 text-2xl font-bold tracking-tight">カート</h1>
+
+      {items.length === 0 ? (
+        // カートが空の場合
+        <CartEmpty />
+      ) : (
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          {/* カートアイテム一覧 */}
+          <section className="lg:col-span-2" aria-label="カートアイテム一覧">
+            {items.map((item) => (
+              <CartItem key={item.id} item={item} />
+            ))}
+          </section>
+
+          {/* 注文サマリー */}
+          <aside aria-label="注文サマリー">
+            <CartSummary
+              totalItems={totalItems()}
+              totalPrice={totalPrice()}
+            />
+          </aside>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/components/features/cart/CartEmpty.tsx
+++ b/src/components/features/cart/CartEmpty.tsx
@@ -1,0 +1,17 @@
+// カートが空の場合に表示するコンポーネント
+import { ShoppingCart } from 'lucide-react'
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+
+export const CartEmpty = () => {
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-24">
+      <ShoppingCart size={64} className="text-muted-foreground" aria-hidden="true" />
+      <p className="text-lg text-muted-foreground">カートに商品がありません</p>
+      <Button asChild>
+        <Link href="/products">商品を見る</Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/components/features/cart/CartItem.tsx
+++ b/src/components/features/cart/CartItem.tsx
@@ -1,0 +1,86 @@
+// カートアイテムコンポーネント
+import { Minus, Plus, Trash2 } from 'lucide-react'
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import { type CartItem as CartItemType, useCartStore } from '@/stores/cartStore'
+
+type Props = {
+  item: CartItemType
+}
+
+// カートアイテムのデフォルト画像サイズ
+const CART_IMAGE_SIZE = 96
+
+export const CartItem = ({ item }: Props) => {
+  const { updateQuantity, removeItem } = useCartStore()
+
+  return (
+    <div className="flex items-center gap-4 border-b py-4">
+      {/* 商品画像 */}
+      <div className="relative h-24 w-24 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+        {item.imageUrl ? (
+          <Image
+            src={item.imageUrl}
+            alt={item.name}
+            width={CART_IMAGE_SIZE}
+            height={CART_IMAGE_SIZE}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground text-xs">
+            No Image
+          </div>
+        )}
+      </div>
+
+      {/* 商品情報 */}
+      <div className="flex flex-1 flex-col gap-2">
+        <p className="font-medium leading-tight">{item.name}</p>
+        <p className="text-sm text-muted-foreground">
+          ¥{item.price.toLocaleString()}
+        </p>
+
+        {/* 数量変更 */}
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => updateQuantity(item.id, item.quantity - 1)}
+            aria-label={`${item.name}の数量を減らす`}
+          >
+            <Minus size={14} />
+          </Button>
+          <span className="w-8 text-center text-sm font-medium" aria-label="数量">
+            {item.quantity}
+          </span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => updateQuantity(item.id, item.quantity + 1)}
+            aria-label={`${item.name}の数量を増やす`}
+          >
+            <Plus size={14} />
+          </Button>
+        </div>
+      </div>
+
+      {/* 小計・削除 */}
+      <div className="flex flex-col items-end gap-2">
+        <p className="font-semibold">
+          ¥{(item.price * item.quantity).toLocaleString()}
+        </p>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+          onClick={() => removeItem(item.id)}
+          aria-label={`${item.name}をカートから削除`}
+        >
+          <Trash2 size={16} />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/cart/CartItem.tsx
+++ b/src/components/features/cart/CartItem.tsx
@@ -1,3 +1,5 @@
+'use client' // 追加
+
 // カートアイテムコンポーネント
 import { Minus, Plus, Trash2 } from 'lucide-react'
 import Image from 'next/image'

--- a/src/components/features/cart/CartSummary.tsx
+++ b/src/components/features/cart/CartSummary.tsx
@@ -1,9 +1,8 @@
 // カート合計サマリーコンポーネント
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-
-// 消費税率（10%）
-const TAX_RATE = 0.1
+import { TAX_RATE } from '@/constants/cart'
+// 変更: TAX_RATEを定数ファイルからimport（コーディング規則: マジック数字を定数化）
 
 type Props = {
   totalItems: number

--- a/src/components/features/cart/CartSummary.tsx
+++ b/src/components/features/cart/CartSummary.tsx
@@ -1,5 +1,4 @@
 // カート合計サマリーコンポーネント
-import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 
@@ -48,9 +47,13 @@ export const CartSummary = ({ totalItems, totalPrice }: Props) => {
         </div>
       </div>
 
-      {/* レジに進むボタン（チェックアウト未実装のため disabled） */}
-      <Button asChild className="mt-6 w-full" disabled>
-        <Link href="/checkout">レジに進む</Link>
+      {/* 変更: レジに進むボタン（アクセシビリティ修正：disabled + Linkを単一buttonに置換） */}
+      <Button
+        className="mt-6 w-full"
+        disabled
+        aria-label="チェックアウト（準備中）"
+      >
+        レジに進む（準備中）
       </Button>
 
       <p className="mt-2 text-center text-xs text-muted-foreground">

--- a/src/components/features/cart/CartSummary.tsx
+++ b/src/components/features/cart/CartSummary.tsx
@@ -1,0 +1,61 @@
+// カート合計サマリーコンポーネント
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+
+// 消費税率（10%）
+const TAX_RATE = 0.1
+
+type Props = {
+  totalItems: number
+  totalPrice: number
+}
+
+export const CartSummary = ({ totalItems, totalPrice }: Props) => {
+  // 税込み合計金額
+  const tax = Math.floor(totalPrice * TAX_RATE)
+  const totalWithTax = totalPrice + tax
+
+  return (
+    <div className="rounded-lg border bg-card p-6">
+      <h2 className="mb-4 text-lg font-semibold">注文サマリー</h2>
+
+      <div className="flex flex-col gap-3 text-sm">
+        {/* 商品点数 */}
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">商品点数</span>
+          <span>{totalItems}点</span>
+        </div>
+
+        {/* 小計 */}
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">小計（税抜）</span>
+          <span>¥{totalPrice.toLocaleString()}</span>
+        </div>
+
+        {/* 消費税 */}
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">消費税（10%）</span>
+          <span>¥{tax.toLocaleString()}</span>
+        </div>
+
+        <Separator />
+
+        {/* 合計 */}
+        <div className="flex justify-between font-semibold text-base">
+          <span>合計（税込）</span>
+          <span>¥{totalWithTax.toLocaleString()}</span>
+        </div>
+      </div>
+
+      {/* レジに進むボタン（チェックアウト未実装のため disabled） */}
+      <Button asChild className="mt-6 w-full" disabled>
+        <Link href="/checkout">レジに進む</Link>
+      </Button>
+
+      <p className="mt-2 text-center text-xs text-muted-foreground">
+        ※チェックアウト機能は近日公開予定です
+      </p>
+    </div>
+  )
+}

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -15,6 +15,7 @@ export const Header = () => {
   const cartCount = useCartStore((state) => state.totalItems())
 
   useEffect(() => {
+    useCartStore.persist.rehydrate() // 追加: 他ページでもlocalStorageからカート状態を復元する
     setMounted(true)
   }, [])
 

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,13 +1,16 @@
 "use client"
 
 // ストアフロント用ヘッダー（Client Component）
-import { useState } from 'react'
-import Link from 'next/link'
 import { ShoppingBag, ShoppingCart, Menu, X } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+import { useCartStore } from '@/stores/cartStore'
 
 export const Header = () => {
   // モバイルメニューの開閉状態
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  // カート合計個数
+  const cartCount = useCartStore((state) => state.totalItems())
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -45,10 +48,16 @@ export const Header = () => {
         <div className="hidden items-center gap-4 md:flex">
           <Link
             href="/cart"
-            aria-label="カートを見る"
-            className="text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={`カートを見る${cartCount > 0 ? `（${cartCount}点）` : ''}`}
+            className="relative text-muted-foreground transition-colors hover:text-foreground"
           >
             <ShoppingCart size={24} />
+            {/* カートバッジ（0件のときは非表示） */}
+            {cartCount > 0 && (
+              <span className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                {cartCount > 99 ? '99+' : cartCount}
+              </span>
+            )}
           </Link>
           <Link
             href="/login"

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -3,14 +3,20 @@
 // ストアフロント用ヘッダー（Client Component）
 import { ShoppingBag, ShoppingCart, Menu, X } from 'lucide-react'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useState } from 'react' // 変更: useEffect を追加
 import { useCartStore } from '@/stores/cartStore'
 
 export const Header = () => {
   // モバイルメニューの開閉状態
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  // 変更: SSRハイドレーション不一致防止のためマウント後にバッジを表示する
+  const [mounted, setMounted] = useState(false)
   // カート合計個数
   const cartCount = useCartStore((state) => state.totalItems())
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -52,8 +58,8 @@ export const Header = () => {
             className="relative text-muted-foreground transition-colors hover:text-foreground"
           >
             <ShoppingCart size={24} />
-            {/* カートバッジ（0件のときは非表示） */}
-            {cartCount > 0 && (
+            {/* 変更: カートバッジ（mountedかつ在庫ありのみ表示） */}
+            {mounted && cartCount > 0 && (
               <span className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
                 {cartCount > 99 ? '99+' : cartCount}
               </span>

--- a/src/constants/cart.ts
+++ b/src/constants/cart.ts
@@ -1,3 +1,5 @@
 // カート関連の定数
 export const CART_STORAGE_KEY = 'cart-storage'
 export const CART_SKELETON_COUNT = 3
+// 消費税率
+export const TAX_RATE = 0.1

--- a/src/constants/cart.ts
+++ b/src/constants/cart.ts
@@ -1,0 +1,3 @@
+// カート関連の定数
+export const CART_STORAGE_KEY = 'cart-storage'
+export const CART_SKELETON_COUNT = 3

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -1,0 +1,85 @@
+// カートの状態管理ストア（Zustand + localStorage永続化）
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+// カートアイテムの型
+export type CartItem = {
+  id: string
+  name: string
+  price: number
+  imageUrl: string | null
+  quantity: number
+}
+
+// カートストアの型
+type CartStore = {
+  items: CartItem[]
+  addItem: (item: Omit<CartItem, 'quantity'>) => void
+  removeItem: (id: string) => void
+  updateQuantity: (id: string, quantity: number) => void
+  clearCart: () => void
+  totalItems: () => number
+  totalPrice: () => number
+}
+
+export const useCartStore = create<CartStore>()(
+  persist(
+    (set, get) => ({
+      items: [],
+
+      // アイテム追加（既存アイテムは数量+1）
+      addItem: (item) => {
+        set((state) => {
+          const existing = state.items.find((i) => i.id === item.id)
+          if (existing) {
+            return {
+              items: state.items.map((i) =>
+                i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+              ),
+            }
+          }
+          return { items: [...state.items, { ...item, quantity: 1 }] }
+        })
+      },
+
+      // アイテム削除
+      removeItem: (id) => {
+        set((state) => ({
+          items: state.items.filter((i) => i.id !== id),
+        }))
+      },
+
+      // 数量更新（0以下の場合は削除）
+      updateQuantity: (id, quantity) => {
+        if (quantity <= 0) {
+          get().removeItem(id)
+          return
+        }
+        set((state) => ({
+          items: state.items.map((i) =>
+            i.id === id ? { ...i, quantity } : i
+          ),
+        }))
+      },
+
+      // カートをクリア
+      clearCart: () => {
+        set({ items: [] })
+      },
+
+      // 合計個数
+      totalItems: () => {
+        return get().items.reduce((sum, i) => sum + i.quantity, 0)
+      },
+
+      // 合計金額
+      totalPrice: () => {
+        return get().items.reduce((sum, i) => sum + i.price * i.quantity, 0)
+      },
+    }),
+    {
+      // localStorageのキー名
+      name: 'cart-storage',
+    }
+  )
+)

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -86,19 +86,18 @@ export const useCartStore = create<CartStore>()(
       // 追加: localStorageから復元したデータのバリデーション
       onRehydrateStorage: () => (state) => {
         if (!state) return
-        // items が配列でない場合はリセット
-        if (!Array.isArray(state.items)) {
-          state.items = []
-        }
-        // 各アイテムの必須フィールドを検証
-        state.items = state.items.filter(
-          (item) =>
-            typeof item.id === 'string' &&
-            typeof item.name === 'string' &&
-            typeof item.price === 'number' &&
-            typeof item.quantity === 'number' &&
-            item.quantity > 0
-        )
+        // 変更: 直接ミューテーションではなく setState 経由で更新
+        const validItems = Array.isArray(state.items)
+          ? state.items.filter(
+              (item) =>
+                typeof item.id === 'string' &&
+                typeof item.name === 'string' &&
+                typeof item.price === 'number' &&
+                typeof item.quantity === 'number' &&
+                item.quantity > 0
+            )
+          : []
+        useCartStore.setState({ items: validItems })
       },
     }
   )

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -1,6 +1,7 @@
 // カートの状態管理ストア（Zustand + localStorage永続化）
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { CART_STORAGE_KEY } from '@/constants/cart' // 追加
 
 // カートアイテムの型
 export type CartItem = {
@@ -79,7 +80,7 @@ export const useCartStore = create<CartStore>()(
     }),
     {
       // localStorageのキー名
-      name: 'cart-storage',
+      name: CART_STORAGE_KEY, // 変更: 定数化
       // 変更: SSRハイドレーション不一致を防ぐため手動ハイドレーションに切り替え
       skipHydration: true,
       // 追加: localStorageから復元したデータのバリデーション

--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -80,6 +80,25 @@ export const useCartStore = create<CartStore>()(
     {
       // localStorageのキー名
       name: 'cart-storage',
+      // 変更: SSRハイドレーション不一致を防ぐため手動ハイドレーションに切り替え
+      skipHydration: true,
+      // 追加: localStorageから復元したデータのバリデーション
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        // items が配列でない場合はリセット
+        if (!Array.isArray(state.items)) {
+          state.items = []
+        }
+        // 各アイテムの必須フィールドを検証
+        state.items = state.items.filter(
+          (item) =>
+            typeof item.id === 'string' &&
+            typeof item.name === 'string' &&
+            typeof item.price === 'number' &&
+            typeof item.quantity === 'number' &&
+            item.quantity > 0
+        )
+      },
     }
   )
 )


### PR DESCRIPTION
## 概要
Issue #15 のカート機能を実装しました。

## 変更内容
- `src/stores/cartStore.ts`: Zustand ストア（追加・削除・数量変更・クリア・persist）
- `src/app/(shop)/cart/page.tsx`: カートページ（Client Component）
- `src/app/(shop)/cart/loading.tsx`: スケルトンUI
- `src/components/features/cart/CartEmpty.tsx`: 空カートコンポーネント
- `src/components/features/cart/CartItem.tsx`: カートアイテムコンポーネント
- `src/components/features/cart/CartSummary.tsx`: 注文サマリー（小計・消費税・合計）
- `src/components/layouts/Header.tsx`: カートバッジ追加
- `package.json` / `pnpm-lock.yaml`: zustand 5.0.12 追加

## 動作確認
- ビルド成功確認
- `/cart` ページで空カート表示を確認

Closes #15