### PR TITLE
feat(checkout): チェックアウト・決済フロー実装（Stripe連携）

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@stripe/react-stripe-js": "^6.2.0",
+    "@stripe/stripe-js": "^9.3.1",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -38,6 +40,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.74.0",
     "server-only": "^0.0.1",
+    "stripe": "^22.1.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@18.3.28)(react@18.3.1)
+      '@stripe/react-stripe-js':
+        specifier: ^6.2.0
+        version: 6.2.0(@stripe/stripe-js@9.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@stripe/stripe-js':
+        specifier: ^9.3.1
+        version: 9.3.1
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -59,6 +65,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      stripe:
+        specifier: ^22.1.0
+        version: 22.1.0(@types/node@20.19.39)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -715,6 +724,17 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stripe/react-stripe-js@6.2.0':
+    resolution: {integrity: sha512-GSCErjljZEQv9LaxP30xGOwstcMyyUzb5JyihXwvjOU95yrfhbiPG4K2KkwxYxn+WY0/AyHsRhPPoGRw7urBzg==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=9.2.0 <10.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@9.3.1':
+    resolution: {integrity: sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==}
+    engines: {node: '>=12.16'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2755,6 +2775,15 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stripe@22.1.0:
+    resolution: {integrity: sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -3584,6 +3613,15 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stripe/react-stripe-js@6.2.0(@stripe/stripe-js@9.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@stripe/stripe-js': 9.3.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@stripe/stripe-js@9.3.1': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -5778,6 +5816,10 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.1.0(@types/node@20.19.39):
+    optionalDependencies:
+      '@types/node': 20.19.39
 
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model Order {
   coupon        Coupon?    @relation(fields: [couponId], references: [id])
 
   stripePaymentIntentId String?
+  shippingAddress       Json?   // 配送先住所
 
   @@map("orders")
 }

--- a/src/app/(shop)/checkout/error.tsx
+++ b/src/app/(shop)/checkout/error.tsx
@@ -1,0 +1,34 @@
+'use client'
+// チェックアウト エラーページ
+import { useEffect } from 'react'
+import { AlertCircle } from 'lucide-react'
+
+type Props = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function CheckoutError({ error, reset }: Props) {
+  useEffect(() => {
+    console.error('[checkout] エラー:', error)
+  }, [error])
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border bg-card p-12 text-center">
+        <AlertCircle size={40} className="text-red-500" aria-hidden="true" />
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">エラーが発生しました</h2>
+          <p className="text-sm text-muted-foreground">チェックアウト中に問題が発生しました。</p>
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          再試行
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/src/app/(shop)/checkout/loading.tsx
+++ b/src/app/(shop)/checkout/loading.tsx
@@ -1,0 +1,23 @@
+// チェックアウト ローディング Skeleton
+export default function CheckoutLoading() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8 h-8 w-40 animate-pulse rounded bg-muted" />
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
+        <div className="lg:col-span-3 space-y-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded bg-muted" />
+          ))}
+          <div className="h-32 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="lg:col-span-2">
+          <div className="rounded-lg border bg-card p-6 space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-5 animate-pulse rounded bg-muted" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(shop)/checkout/page.tsx
+++ b/src/app/(shop)/checkout/page.tsx
@@ -39,7 +39,6 @@ export default function CheckoutPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             items: items.map(({ id, quantity }) => ({ id, quantity })),
-
           }),
         })
 
@@ -68,7 +67,8 @@ export default function CheckoutPage() {
     }
 
     void createPaymentIntent()
-  }, [mounted, items, router])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mounted])
 
   // 税込合計
   const tax = Math.floor(totalPrice() * 0.1)

--- a/src/app/(shop)/checkout/page.tsx
+++ b/src/app/(shop)/checkout/page.tsx
@@ -1,0 +1,144 @@
+'use client'
+// チェックアウトページ（認証チェック + PaymentIntent 取得 + Stripe Elements レンダリング）
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Elements } from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
+import { CheckoutForm } from '@/components/features/checkout/CheckoutForm'
+import { useCartStore } from '@/stores/cartStore'
+
+// Stripe publishable key（クライアントサイド）
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '')
+
+export default function CheckoutPage() {
+  const router = useRouter()
+  const { items, totalPrice } = useCartStore()
+  const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [paymentIntentId, setPaymentIntentId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    useCartStore.persist.rehydrate()
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!mounted) return
+    // カートが空の場合はカートページへリダイレクト
+    if (items.length === 0) {
+      router.replace('/cart')
+      return
+    }
+
+    // PaymentIntent を作成して clientSecret を取得
+    const createPaymentIntent = async () => {
+      try {
+        const res = await fetch('/api/stripe/payment-intent', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: items.map(({ id, quantity }) => ({ id, quantity })),
+
+          }),
+        })
+
+        if (res.status === 401) {
+          router.replace('/login?redirect=/checkout')
+          return
+        }
+
+        if (!res.ok) {
+          const json: unknown = await res.json()
+          const message =
+            json !== null && typeof json === 'object' && 'error' in json && typeof (json as Record<string, unknown>).error === 'string'
+              ? (json as Record<string, unknown>).error as string
+              : '決済の準備に失敗しました'
+          setError(message)
+          return
+        }
+
+        const { clientSecret: secret, paymentIntentId: piId } = (await res.json()) as { clientSecret: string; paymentIntentId: string }
+        setClientSecret(secret)
+        setPaymentIntentId(piId)
+      } catch (err) {
+        console.error('[checkout] PaymentIntent 取得エラー:', err)
+        setError('決済の準備中にエラーが発生しました')
+      }
+    }
+
+    void createPaymentIntent()
+  }, [mounted, items, router])
+
+  // 税込合計
+  const tax = Math.floor(totalPrice() * 0.1)
+  const totalWithTax = totalPrice() + tax
+
+  if (!mounted) return null
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="mb-8 text-2xl font-bold tracking-tight">チェックアウト</h1>
+
+      {error && (
+        <div role="alert" className="mb-6 rounded-md bg-red-50 p-4 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
+        {/* チェックアウトフォーム */}
+        <div className="lg:col-span-3">
+          {clientSecret && paymentIntentId ? (
+            <Elements
+              stripe={stripePromise}
+              options={{ clientSecret, locale: 'ja' }}
+            >
+              <CheckoutForm clientSecret={clientSecret} paymentIntentId={paymentIntentId} />
+            </Elements>
+          ) : (
+            !error && (
+              <div className="space-y-4 animate-pulse">
+                <div className="h-10 rounded bg-muted" />
+                <div className="h-10 rounded bg-muted" />
+                <div className="h-32 rounded bg-muted" />
+              </div>
+            )
+          )}
+        </div>
+
+        {/* 注文サマリー */}
+        <aside className="lg:col-span-2" aria-label="注文サマリー">
+          <div className="rounded-lg border bg-card p-6 text-sm">
+            <h2 className="mb-4 font-semibold text-base">注文内容</h2>
+            <ul className="mb-4 space-y-2">
+              {items.map((item) => (
+                <li key={item.id} className="flex justify-between gap-2">
+                  <span className="text-muted-foreground">
+                    {item.name} × {item.quantity}
+                  </span>
+                  <span>¥{(item.price * item.quantity).toLocaleString()}</span>
+                </li>
+              ))}
+            </ul>
+            <hr className="my-3" />
+            <div className="space-y-1">
+              <div className="flex justify-between text-muted-foreground">
+                <span>小計（税抜）</span>
+                <span>¥{totalPrice().toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between text-muted-foreground">
+                <span>消費税（10%）</span>
+                <span>¥{tax.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between font-semibold text-base pt-2">
+                <span>合計（税込）</span>
+                <span>¥{totalWithTax.toLocaleString()}</span>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  )
+}

--- a/src/app/(shop)/checkout/success/page.tsx
+++ b/src/app/(shop)/checkout/success/page.tsx
@@ -1,0 +1,36 @@
+// 注文完了ページ（Stripe リダイレクト後）
+import Link from 'next/link'
+import { CheckCircle2 } from 'lucide-react'
+
+export default function CheckoutSuccessPage() {
+  return (
+    <main className="mx-auto max-w-lg px-4 py-16 sm:px-6 lg:px-8">
+      <div className="flex flex-col items-center gap-6 text-center">
+        <CheckCircle2 size={56} className="text-green-500" aria-hidden="true" />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">ご注文ありがとうございます</h1>
+          <p className="text-muted-foreground">
+            ご注文を受け付けました。
+            <br />
+            注文確認メールをお送りしましたのでご確認ください。
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 w-full sm:flex-row sm:justify-center">
+          <Link
+            href="/orders"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            注文履歴を確認する
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-md border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            ショッピングを続ける
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -2,7 +2,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { createOrder } from '@/lib/db/orders'
-import { findProductById } from '@/lib/db/products'
+import { validateCartItems } from '@/lib/db/products'
+import type { Prisma } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
 
 type CartItemInput = {
@@ -40,15 +41,7 @@ export const POST = async (req: NextRequest) => {
 
   try {
     // 各商品の最新価格・在庫を DB から取得して検証
-    const productData = await Promise.all(
-      items.map(async ({ id, quantity }) => {
-        const product = await findProductById(id)
-        if (!product) throw new Error(`商品が見つかりません: ${id}`)
-        if (!product.isPublished) throw new Error(`非公開商品です: ${id}`)
-        if (product.stock < quantity) throw new Error(`在庫不足: ${product.name}`)
-        return { product, quantity }
-      })
-    )
+    const productData = await validateCartItems(items)
 
     // 合計金額（税込10%）
     const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)
@@ -59,7 +52,7 @@ export const POST = async (req: NextRequest) => {
       status: 'PENDING',
       totalPrice,
       stripePaymentIntentId,
-      shippingAddress: shippingAddress as unknown as import('@/generated/prisma/client').Prisma.InputJsonValue,
+      shippingAddress: shippingAddress as unknown as Prisma.InputJsonValue,
       user: { connect: { id: session.user.id } },
       items: {
         create: productData.map(({ product, quantity }) => ({

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,79 @@
+// 注文作成 API（チェックアウトフォーム送信時に呼ばれる）
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { createOrder } from '@/lib/db/orders'
+import { findProductById } from '@/lib/db/products'
+import type { ShippingAddress } from '@/constants/checkout'
+
+type CartItemInput = {
+  id: string
+  quantity: number
+}
+
+type RequestBody = {
+  items: CartItemInput[]
+  shippingAddress: ShippingAddress
+  stripePaymentIntentId: string
+}
+
+// POST /api/orders
+export const POST = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  const body: unknown = await req.json()
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    !('items' in body) ||
+    !('shippingAddress' in body) ||
+    !('stripePaymentIntentId' in body) ||
+    !Array.isArray((body as RequestBody).items) ||
+    (body as RequestBody).items.length === 0
+  ) {
+    return NextResponse.json({ error: 'リクエストが不正です', code: 'BAD_REQUEST' }, { status: 400 })
+  }
+
+  const { items, shippingAddress, stripePaymentIntentId } = body as RequestBody
+
+  try {
+    // 各商品の最新価格・在庫を DB から取得して検証
+    const productData = await Promise.all(
+      items.map(async ({ id, quantity }) => {
+        const product = await findProductById(id)
+        if (!product) throw new Error(`商品が見つかりません: ${id}`)
+        if (!product.isPublished) throw new Error(`非公開商品です: ${id}`)
+        if (product.stock < quantity) throw new Error(`在庫不足: ${product.name}`)
+        return { product, quantity }
+      })
+    )
+
+    // 合計金額（税込10%）
+    const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)
+    const tax = Math.floor(subtotal * 0.1)
+    const totalPrice = subtotal + tax
+
+    const order = await createOrder({
+      status: 'PENDING',
+      totalPrice,
+      stripePaymentIntentId,
+      shippingAddress: shippingAddress as unknown as import('@/generated/prisma/client').Prisma.InputJsonValue,
+      user: { connect: { id: session.user.id } },
+      items: {
+        create: productData.map(({ product, quantity }) => ({
+          quantity,
+          unitPrice: product.price,
+          product: { connect: { id: product.id } },
+        })),
+      },
+    })
+
+    return NextResponse.json({ orderId: order.id }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[orders POST] エラー:', err)
+    return NextResponse.json({ error: message, code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/payment-intent/route.ts
+++ b/src/app/api/stripe/payment-intent/route.ts
@@ -1,0 +1,69 @@
+// Stripe PaymentIntent 作成 API
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { findProductById } from '@/lib/db/products'
+import { stripe } from '@/lib/stripe'
+
+type CartItemInput = {
+  id: string
+  quantity: number
+}
+
+type RequestBody = {
+  items: CartItemInput[]
+}
+
+// POST /api/stripe/payment-intent
+export const POST = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  const body: unknown = await req.json()
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    !('items' in body) ||
+    !Array.isArray((body as RequestBody).items) ||
+    (body as RequestBody).items.length === 0
+  ) {
+    return NextResponse.json({ error: 'カートが空です', code: 'BAD_REQUEST' }, { status: 400 })
+  }
+
+  const { items } = body as RequestBody
+
+  try {
+    // 各商品の最新価格・在庫を DB から取得して検証
+    const productData = await Promise.all(
+      items.map(async ({ id, quantity }) => {
+        const product = await findProductById(id)
+        if (!product) throw new Error(`商品が見つかりません: ${id}`)
+        if (!product.isPublished) throw new Error(`非公開商品です: ${id}`)
+        if (product.stock < quantity) throw new Error(`在庫不足: ${product.name}`)
+        return { product, quantity }
+      })
+    )
+
+    // 合計金額（円単位・税込10%）
+    const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)
+    const tax = Math.floor(subtotal * 0.1)
+    const totalPrice = subtotal + tax
+
+    // Stripe PaymentIntent 作成（金額は円単位なので通貨は jpy）
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: totalPrice,
+      currency: 'jpy',
+      automatic_payment_methods: { enabled: true },
+    })
+
+    return NextResponse.json({
+      clientSecret: paymentIntent.client_secret,
+      paymentIntentId: paymentIntent.id,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[stripe/payment-intent POST] エラー:', err)
+    return NextResponse.json({ error: message, code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/payment-intent/route.ts
+++ b/src/app/api/stripe/payment-intent/route.ts
@@ -1,7 +1,7 @@
 // Stripe PaymentIntent 作成 API
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { findProductById } from '@/lib/db/products'
+import { validateCartItems } from '@/lib/db/products'
 import { stripe } from '@/lib/stripe'
 
 type CartItemInput = {
@@ -35,15 +35,7 @@ export const POST = async (req: NextRequest) => {
 
   try {
     // 各商品の最新価格・在庫を DB から取得して検証
-    const productData = await Promise.all(
-      items.map(async ({ id, quantity }) => {
-        const product = await findProductById(id)
-        if (!product) throw new Error(`商品が見つかりません: ${id}`)
-        if (!product.isPublished) throw new Error(`非公開商品です: ${id}`)
-        if (product.stock < quantity) throw new Error(`在庫不足: ${product.name}`)
-        return { product, quantity }
-      })
-    )
+    const productData = await validateCartItems(items)
 
     // 合計金額（円単位・税込10%）
     const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,51 @@
+// Stripe Webhook 受信 API
+import { headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import type Stripe from 'stripe'
+import { env } from '@/env'
+import { updateOrderToPaidByStripeId } from '@/lib/db/orders'
+import { stripe } from '@/lib/stripe'
+
+// Next.js App Router では生の body 読み取りのため bodyParser を無効化
+export const dynamic = 'force-dynamic'
+
+// POST /api/stripe/webhook
+export const POST = async (req: NextRequest) => {
+  const body = await req.text()
+  const headersList = await headers()
+  const sig = headersList.get('stripe-signature')
+
+  if (!sig) {
+    return NextResponse.json({ error: 'stripe-signature ヘッダーがありません' }, { status: 400 })
+  }
+
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, env.STRIPE_WEBHOOK_SECRET)
+  } catch (err) {
+    console.error('[stripe/webhook] 署名検証失敗:', err)
+    return NextResponse.json({ error: 'Webhook 署名の検証に失敗しました' }, { status: 400 })
+  }
+
+  try {
+    switch (event.type) {
+      case 'payment_intent.succeeded': {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent
+        await updateOrderToPaidByStripeId(paymentIntent.id)
+        break
+      }
+      case 'payment_intent.payment_failed': {
+        // 必要に応じてキャンセル処理などを追加
+        break
+      }
+      default:
+        // 未処理イベントは無視
+        break
+    }
+  } catch (err) {
+    console.error('[stripe/webhook] イベント処理エラー:', err)
+    return NextResponse.json({ error: 'イベント処理に失敗しました' }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/src/components/features/cart/CartSummary.tsx
+++ b/src/components/features/cart/CartSummary.tsx
@@ -1,4 +1,5 @@
 // カート合計サマリーコンポーネント
+import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { TAX_RATE } from '@/constants/cart'
@@ -46,18 +47,12 @@ export const CartSummary = ({ totalItems, totalPrice }: Props) => {
         </div>
       </div>
 
-      {/* 変更: レジに進むボタン（アクセシビリティ修正：disabled + Linkを単一buttonに置換） */}
-      <Button
-        className="mt-6 w-full"
-        disabled
-        aria-label="チェックアウト（準備中）"
-      >
-        レジに進む（準備中）
+      {/* 変更: レジに進むボタン（チェックアウトページへのリンク） */}
+      <Button asChild className="mt-6 w-full">
+        <Link href="/checkout" aria-label="チェックアウトへ進む">
+          レジに進む
+        </Link>
       </Button>
-
-      <p className="mt-2 text-center text-xs text-muted-foreground">
-        ※チェックアウト機能は近日公開予定です
-      </p>
     </div>
   )
 }

--- a/src/components/features/checkout/CheckoutForm.tsx
+++ b/src/components/features/checkout/CheckoutForm.tsx
@@ -1,0 +1,276 @@
+'use client'
+// チェックアウトフォームコンポーネント（配送先入力 + Stripe Elements）
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  PaymentElement,
+  useElements,
+  useStripe,
+} from '@stripe/react-stripe-js'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { CHECKOUT_SUCCESS_PATH } from '@/constants/checkout'
+import { useCartStore } from '@/stores/cartStore'
+
+// 配送先フォームのバリデーションスキーマ
+const shippingSchema = z.object({
+  name: z.string().min(1, 'お名前を入力してください'),
+  phone: z.string().min(10, '電話番号を入力してください').max(15),
+  postalCode: z.string().regex(/^\d{7}$/, '郵便番号は7桁の数字で入力してください'),
+  prefecture: z.string().min(1, '都道府県を入力してください'),
+  city: z.string().min(1, '市区町村を入力してください'),
+  addressLine1: z.string().min(1, '番地を入力してください'),
+  addressLine2: z.string().optional(),
+})
+
+type ShippingFormValues = z.infer<typeof shippingSchema>
+
+type Props = {
+  clientSecret: string
+  paymentIntentId: string
+}
+
+export const CheckoutForm = ({ clientSecret, paymentIntentId }: Props) => {
+  const router = useRouter()
+  const stripeInstance = useStripe()
+  const elements = useElements()
+  const { clearCart, items } = useCartStore()
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [paymentError, setPaymentError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ShippingFormValues>({
+    resolver: zodResolver(shippingSchema),
+  })
+
+  const onSubmit = async (data: ShippingFormValues) => {
+    if (!stripeInstance || !elements) return
+
+    setIsProcessing(true)
+    setPaymentError(null)
+
+    // Stripe Elements の入力確定
+    const { error: submitError } = await elements.submit()
+    if (submitError) {
+      setPaymentError(submitError.message ?? '決済情報の確認に失敗しました')
+      setIsProcessing(false)
+      return
+    }
+
+    // 注文を DB に保存（配送先情報 + PaymentIntent ID）
+    const orderRes = await fetch('/api/orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: items.map(({ id, quantity }) => ({ id, quantity })),
+        shippingAddress: data,
+        stripePaymentIntentId: paymentIntentId,
+      }),
+    })
+
+    if (!orderRes.ok) {
+      const json: unknown = await orderRes.json()
+      const message =
+        json !== null && typeof json === 'object' && 'error' in json && typeof (json as Record<string, unknown>).error === 'string'
+          ? (json as Record<string, unknown>).error as string
+          : '注文の作成に失敗しました'
+      setPaymentError(message)
+      setIsProcessing(false)
+      return
+    }
+
+    // 決済実行
+    const { error } = await stripeInstance.confirmPayment({
+      elements,
+      clientSecret,
+      confirmParams: {
+        return_url: `${window.location.origin}${CHECKOUT_SUCCESS_PATH}`,
+      },
+    })
+
+    if (error) {
+      setPaymentError(error.message ?? '決済に失敗しました')
+      setIsProcessing(false)
+      return
+    }
+
+    // 成功時はカートをクリア（リダイレクト前）
+    clearCart()
+    router.push(CHECKOUT_SUCCESS_PATH)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-8" noValidate>
+      {/* 配送先情報 */}
+      <section aria-labelledby="shipping-heading">
+        <h2 id="shipping-heading" className="mb-4 text-lg font-semibold">
+          配送先情報
+        </h2>
+        <div className="space-y-4">
+          {/* お名前 */}
+          <div className="space-y-1">
+            <label htmlFor="name" className="block text-sm font-medium">
+              お名前 <span className="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="name"
+              type="text"
+              {...register('name')}
+              autoComplete="name"
+              className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-describedby={errors.name ? 'name-error' : undefined}
+            />
+            {errors.name && (
+              <p id="name-error" className="text-xs text-red-500">{errors.name.message}</p>
+            )}
+          </div>
+
+          {/* 電話番号 */}
+          <div className="space-y-1">
+            <label htmlFor="phone" className="block text-sm font-medium">
+              電話番号 <span className="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="phone"
+              type="tel"
+              {...register('phone')}
+              autoComplete="tel"
+              placeholder="09012345678"
+              className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-describedby={errors.phone ? 'phone-error' : undefined}
+            />
+            {errors.phone && (
+              <p id="phone-error" className="text-xs text-red-500">{errors.phone.message}</p>
+            )}
+          </div>
+
+          {/* 郵便番号 */}
+          <div className="space-y-1">
+            <label htmlFor="postalCode" className="block text-sm font-medium">
+              郵便番号 <span className="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="postalCode"
+              type="text"
+              {...register('postalCode')}
+              autoComplete="postal-code"
+              placeholder="1234567"
+              maxLength={7}
+              className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-describedby={errors.postalCode ? 'postal-code-error' : undefined}
+            />
+            {errors.postalCode && (
+              <p id="postal-code-error" className="text-xs text-red-500">{errors.postalCode.message}</p>
+            )}
+          </div>
+
+          {/* 都道府県・市区町村 */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label htmlFor="prefecture" className="block text-sm font-medium">
+                都道府県 <span className="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input
+                id="prefecture"
+                type="text"
+                {...register('prefecture')}
+                autoComplete="address-level1"
+                placeholder="東京都"
+                className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                aria-describedby={errors.prefecture ? 'prefecture-error' : undefined}
+              />
+              {errors.prefecture && (
+                <p id="prefecture-error" className="text-xs text-red-500">{errors.prefecture.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="city" className="block text-sm font-medium">
+                市区町村 <span className="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input
+                id="city"
+                type="text"
+                {...register('city')}
+                autoComplete="address-level2"
+                placeholder="渋谷区"
+                className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                aria-describedby={errors.city ? 'city-error' : undefined}
+              />
+              {errors.city && (
+                <p id="city-error" className="text-xs text-red-500">{errors.city.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* 番地 */}
+          <div className="space-y-1">
+            <label htmlFor="addressLine1" className="block text-sm font-medium">
+              番地 <span className="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="addressLine1"
+              type="text"
+              {...register('addressLine1')}
+              autoComplete="address-line1"
+              placeholder="1-2-3"
+              className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-describedby={errors.addressLine1 ? 'address-line1-error' : undefined}
+            />
+            {errors.addressLine1 && (
+              <p id="address-line1-error" className="text-xs text-red-500">{errors.addressLine1.message}</p>
+            )}
+          </div>
+
+          {/* 建物名・部屋番号（任意） */}
+          <div className="space-y-1">
+            <label htmlFor="addressLine2" className="block text-sm font-medium">
+              建物名・部屋番号
+            </label>
+            <input
+              id="addressLine2"
+              type="text"
+              {...register('addressLine2')}
+              autoComplete="address-line2"
+              placeholder="○○マンション 101号室"
+              className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 決済情報 */}
+      <section aria-labelledby="payment-heading">
+        <h2 id="payment-heading" className="mb-4 text-lg font-semibold">
+          お支払い情報
+        </h2>
+        <div className="rounded-md border p-4">
+          <PaymentElement />
+        </div>
+      </section>
+
+      {/* エラーメッセージ */}
+      {paymentError && (
+        <div
+          role="alert"
+          className="rounded-md bg-red-50 p-3 text-sm text-red-600"
+        >
+          {paymentError}
+        </div>
+      )}
+
+      {/* 送信ボタン */}
+      <button
+        type="submit"
+        disabled={isProcessing || !stripeInstance || !elements}
+        className="w-full rounded-md bg-primary py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+        aria-busy={isProcessing}
+      >
+        {isProcessing ? '決済処理中...' : '注文を確定する'}
+      </button>
+    </form>
+  )
+}

--- a/src/constants/checkout.ts
+++ b/src/constants/checkout.ts
@@ -1,0 +1,14 @@
+// チェックアウト関連の定数
+export const CHECKOUT_SUCCESS_PATH = '/checkout/success'
+export const CHECKOUT_CANCEL_PATH = '/cart'
+
+// 配送先住所の型
+export type ShippingAddress = {
+  postalCode: string
+  prefecture: string
+  city: string
+  addressLine1: string
+  addressLine2?: string
+  name: string
+  phone: string
+}

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -43,3 +43,16 @@ export const createOrder = async (data: Prisma.OrderCreateInput) => {
 export const updateOrderStatus = async (id: string, status: OrderStatus) => {
   return prisma.order.update({ where: { id }, data: { status } })
 }
+
+// 追加: PaymentIntent ID を注文に紐付ける
+export const updateOrderStripeId = async (id: string, stripePaymentIntentId: string) => {
+  return prisma.order.update({ where: { id }, data: { stripePaymentIntentId } })
+}
+
+// 追加: PaymentIntent ID で注文を検索して PAID に更新
+export const updateOrderToPaidByStripeId = async (stripePaymentIntentId: string) => {
+  return prisma.order.updateMany({
+    where: { stripePaymentIntentId },
+    data: { status: 'PAID' },
+  })
+}

--- a/src/lib/db/products.ts
+++ b/src/lib/db/products.ts
@@ -94,3 +94,21 @@ export const findProductByIdForAdmin = async (id: string) => {
     include: { category: true },
   })
 }
+
+type CartItemInput = {
+  id: string
+  quantity: number
+}
+
+// 追加: カートアイテムの商品検証（存在・公開・在庫確認）を共通化
+export const validateCartItems = async (items: CartItemInput[]) => {
+  return Promise.all(
+    items.map(async ({ id, quantity }) => {
+      const product = await findProductById(id)
+      if (!product) throw new Error(`商品が見つかりません: ${id}`)
+      if (!product.isPublished) throw new Error(`非公開商品です: ${id}`)
+      if (product.stock < quantity) throw new Error(`在庫不足: ${product.name}`)
+      return { product, quantity }
+    })
+  )
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,9 @@
+// Stripe サーバーサイドクライアント
+import 'server-only'
+import Stripe from 'stripe'
+import { env } from '@/env'
+
+export const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
+  apiVersion: '2026-04-22.dahlia',
+  typescript: true,
+})


### PR DESCRIPTION
## 概要
Stripe Payment Intents を使ったチェックアウト・決済フローを実装しました。

## 変更内容
- `prisma/schema.prisma`: Order に shippingAddress Json? フィールド追加
- `src/lib/stripe.ts`: Stripe サーバーサイドクライアント
- `src/constants/checkout.ts`: チェックアウト関連定数・ShippingAddress型
- `src/lib/db/orders.ts`: updateOrderStripeId・updateOrderToPaidByStripeId 追加
- `src/app/api/stripe/payment-intent/route.ts`: PaymentIntent 作成 API
- `src/app/api/stripe/webhook/route.ts`: Webhook 受信・PAID更新 API
- `src/app/api/orders/route.ts`: 注文作成 API（配送先・PaymentIntent紐付け）
- `src/components/features/checkout/CheckoutForm.tsx`: 配送先入力 + Stripe Elements
- `src/app/(shop)/checkout/page.tsx`: チェックアウトページ
- `src/app/(shop)/checkout/loading.tsx`: ローディング Skeleton
- `src/app/(shop)/checkout/error.tsx`: エラーページ
- `src/app/(shop)/checkout/success/page.tsx`: 注文完了ページ
- `src/components/features/cart/CartSummary.tsx`: レジに進むボタン有効化

## 決済フロー
1. チェックアウトページ表示時に PaymentIntent を作成（clientSecret 取得）
2. ユーザーが配送先・カード情報を入力
3. フォーム送信時に注文を DB 作成（PENDING）
4. Stripe で決済確定 → 注文完了ページへ
5. Webhook で payment_intent.succeeded 受信 → 注文を PAID に更新

## 備考
- DB マイグレーション（shippingAddress フィールド）は DB 起動後に実行が必要

Closes #25