### PR TITLE
feat(admin): 管理画面注文管理を実装（一覧・詳細・ステータス変更）

### DIFF
--- a/src/app/(admin)/admin/orders/[id]/page.tsx
+++ b/src/app/(admin)/admin/orders/[id]/page.tsx
@@ -1,0 +1,23 @@
+// 管理画面 注文詳細ページ（Server Component）
+import { notFound } from 'next/navigation'
+import { findOrderById } from '@/lib/db/orders'
+import { OrderDetail } from '@/components/features/admin/OrderDetail'
+
+export const metadata = {
+  title: '注文詳細 | 管理画面',
+}
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function AdminOrderDetailPage({ params }: Props) {
+  const { id } = await params
+  const order = await findOrderById(id)
+
+  if (!order) {
+    notFound()
+  }
+
+  return <OrderDetail order={order} />
+}

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,0 +1,57 @@
+// 管理画面 注文一覧ページ（Server Component）
+import { Suspense } from 'react'
+import type { OrderStatus } from '@/generated/prisma/client'
+import { findOrders } from '@/lib/db/orders'
+import { countOrders } from '@/lib/db/orders'
+import { OrderTable } from '@/components/features/admin/OrderTable'
+import { ADMIN_ORDER_PAGE_SIZE } from '@/constants/admin'
+
+export const metadata = {
+  title: '注文管理 | 管理画面',
+}
+
+const VALID_STATUSES: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
+
+type SearchParams = {
+  status?: string
+  page?: string
+}
+
+type Props = {
+  searchParams: Promise<SearchParams>
+}
+
+export default async function AdminOrdersPage({ searchParams }: Props) {
+  const { status: statusParam, page: pageParam } = await searchParams
+
+  const status =
+    statusParam && VALID_STATUSES.includes(statusParam as OrderStatus)
+      ? (statusParam as OrderStatus)
+      : undefined
+
+  const page = Math.max(1, Number(pageParam ?? 1))
+  const skip = (page - 1) * ADMIN_ORDER_PAGE_SIZE
+
+  const [orders, total] = await Promise.all([
+    findOrders({ status, take: ADMIN_ORDER_PAGE_SIZE, skip }),
+    countOrders({ status }),
+  ])
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">注文管理</h1>
+        <p className="text-sm text-muted-foreground">注文の一覧・詳細確認・ステータス変更</p>
+      </div>
+
+      <Suspense>
+        <OrderTable
+          orders={orders}
+          total={total}
+          currentPage={page}
+          currentStatus={statusParam ?? ''}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,8 +1,7 @@
 // 管理画面 注文一覧ページ（Server Component）
 import { Suspense } from 'react'
 import type { OrderStatus } from '@/generated/prisma/client'
-import { findOrders } from '@/lib/db/orders'
-import { countOrders } from '@/lib/db/orders'
+import { countOrders, findOrders } from '@/lib/db/orders'
 import { OrderTable } from '@/components/features/admin/OrderTable'
 import { ADMIN_ORDER_PAGE_SIZE } from '@/constants/admin'
 
@@ -44,7 +43,7 @@ export default async function AdminOrdersPage({ searchParams }: Props) {
         <p className="text-sm text-muted-foreground">注文の一覧・詳細確認・ステータス変更</p>
       </div>
 
-      <Suspense>
+      <Suspense fallback={<p className="text-sm text-muted-foreground">読み込み中...</p>}>
         <OrderTable
           orders={orders}
           total={total}

--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -1,0 +1,79 @@
+// 管理画面 注文詳細・ステータス変更 API
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAdmin } from '@/lib/admin-auth'
+import { findOrderById, updateOrderStatus } from '@/lib/db/orders'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+const updateStatusSchema = z.object({
+  status: z.enum(['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']),
+})
+
+// GET /api/admin/orders/:id - 注文詳細取得
+export const GET = async (_req: NextRequest, { params }: RouteParams) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { id } = await params
+
+  try {
+    const order = await findOrderById(id)
+    if (!order) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    return NextResponse.json({ order })
+  } catch (err) {
+    console.error('[admin/orders/:id GET] エラー:', err)
+    return NextResponse.json({ error: '注文の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}
+
+// PATCH /api/admin/orders/:id - 注文ステータス変更
+export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { id } = await params
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = updateStatusSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '無効なステータスです', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const { status } = parsed.data
+
+    const existing = await findOrderById(id)
+    if (!existing) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+
+    // キャンセル済みの注文は変更不可
+    if (existing.status === 'CANCELLED') {
+      return NextResponse.json(
+        { error: 'キャンセル済みの注文はステータスを変更できません', code: 'BAD_REQUEST' },
+        { status: 400 },
+      )
+    }
+
+    const updated = await updateOrderStatus(id, status)
+    return NextResponse.json({ order: updated })
+  } catch (err) {
+    console.error('[admin/orders/:id PATCH] エラー:', err)
+    return NextResponse.json(
+      { error: '注文ステータスの更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -1,0 +1,36 @@
+// 管理画面 注文一覧 API
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import { countOrders, findOrders } from '@/lib/db/orders'
+import type { OrderStatus } from '@/generated/prisma/client'
+
+const VALID_STATUSES: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
+
+// GET /api/admin/orders - 注文一覧取得（フィルター・ページネーション対応）
+export const GET = async (req: NextRequest) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { searchParams } = req.nextUrl
+  const statusParam = searchParams.get('status')
+  const take = Number(searchParams.get('take') ?? 20)
+  const skip = Number(searchParams.get('skip') ?? 0)
+
+  const status =
+    statusParam && VALID_STATUSES.includes(statusParam as OrderStatus)
+      ? (statusParam as OrderStatus)
+      : undefined
+
+  try {
+    const [orders, total] = await Promise.all([
+      findOrders({ status, take, skip }),
+      countOrders({ status }),
+    ])
+    return NextResponse.json({ orders, total })
+  } catch (err) {
+    console.error('[admin/orders GET] エラー:', err)
+    return NextResponse.json({ error: '注文一覧の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -15,7 +15,7 @@ export const GET = async (req: NextRequest) => {
 
   const { searchParams } = req.nextUrl
   const statusParam = searchParams.get('status')
-  const take = Number(searchParams.get('take') ?? 20)
+  const take = Math.min(Number(searchParams.get('take') ?? 20), 100)
   const skip = Number(searchParams.get('skip') ?? 0)
 
   const status =

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -7,6 +7,17 @@ import { useState } from 'react'
 import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
 import type { Coupon, Order, OrderItem, OrderStatus, Product, User } from '@/generated/prisma/client'
 
+// 配送先住所の型定義
+type ShippingAddress = {
+  name?: string
+  postalCode?: string
+  prefecture?: string
+  city?: string
+  line1?: string
+  line2?: string
+  phone?: string
+}
+
 type OrderWithRelations = Order & {
   user: Pick<User, 'id' | 'email' | 'name'>
   items: (OrderItem & { product: Product })[]
@@ -74,17 +85,6 @@ export const OrderDetail = ({ order }: Props) => {
     } finally {
       setIsUpdating(false)
     }
-  }
-
-  // 配送先住所の型定義
-  type ShippingAddress = {
-    name?: string
-    postalCode?: string
-    prefecture?: string
-    city?: string
-    line1?: string
-    line2?: string
-    phone?: string
   }
 
   const shipping =

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -1,0 +1,268 @@
+'use client'
+// 管理画面 注文詳細コンポーネント
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
+import type { Coupon, Order, OrderItem, OrderStatus, Product, User } from '@/generated/prisma/client'
+
+type OrderWithRelations = Order & {
+  user: Pick<User, 'id' | 'email' | 'name'>
+  items: (OrderItem & { product: Product })[]
+  coupon: Coupon | null
+}
+
+type Props = {
+  order: OrderWithRelations
+}
+
+// 遷移可能な次のステータス一覧
+const NEXT_STATUSES: Record<OrderStatus, OrderStatus[]> = {
+  PENDING: ['PAID', 'CANCELLED'],
+  PAID: ['SHIPPED', 'CANCELLED'],
+  SHIPPED: ['DELIVERED', 'CANCELLED'],
+  DELIVERED: [],
+  CANCELLED: [],
+}
+
+const STATUS_OPTIONS: { value: OrderStatus; label: string }[] = [
+  { value: 'PENDING', label: '未払い' },
+  { value: 'PAID', label: '支払済' },
+  { value: 'SHIPPED', label: '発送済' },
+  { value: 'DELIVERED', label: '配達完了' },
+  { value: 'CANCELLED', label: 'キャンセル' },
+]
+
+export const OrderDetail = ({ order }: Props) => {
+  const router = useRouter()
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  const nextStatuses = NEXT_STATUSES[order.status] ?? []
+
+  const handleStatusChange = async (newStatus: OrderStatus) => {
+    const label = STATUS_OPTIONS.find((o) => o.value === newStatus)?.label ?? newStatus
+    if (!confirm(`ステータスを「${label}」に変更してもよいですか？`)) return
+
+    setIsUpdating(true)
+    setErrorMsg(null)
+
+    try {
+      const res = await fetch(`/api/admin/orders/${order.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      })
+
+      if (!res.ok) {
+        const data: unknown = await res.json()
+        const msg =
+          data !== null &&
+          typeof data === 'object' &&
+          'error' in data &&
+          typeof (data as { error: unknown }).error === 'string'
+            ? (data as { error: string }).error
+            : 'ステータスの更新に失敗しました'
+        setErrorMsg(msg)
+        return
+      }
+
+      router.refresh()
+    } catch {
+      setErrorMsg('ステータスの更新中にエラーが発生しました')
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  // 配送先住所の型定義
+  type ShippingAddress = {
+    name?: string
+    postalCode?: string
+    prefecture?: string
+    city?: string
+    line1?: string
+    line2?: string
+    phone?: string
+  }
+
+  const shipping =
+    order.shippingAddress !== null && typeof order.shippingAddress === 'object'
+      ? (order.shippingAddress as ShippingAddress)
+      : null
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      {/* 戻るリンク */}
+      <Link
+        href="/admin/orders"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft size={16} aria-hidden="true" />
+        注文一覧に戻る
+      </Link>
+
+      {/* ヘッダー */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">注文詳細</h1>
+          <p className="mt-1 font-mono text-sm text-muted-foreground">ID: {order.id}</p>
+        </div>
+        <span
+          className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
+            ORDER_STATUS_CLASS[order.status] ?? 'bg-gray-100 text-gray-800'
+          }`}
+        >
+          {ORDER_STATUS_LABEL[order.status] ?? order.status}
+        </span>
+      </div>
+
+      {/* ステータス変更 */}
+      {nextStatuses.length > 0 && (
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold">ステータスを変更</h2>
+          {errorMsg && (
+            <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600" role="alert">
+              {errorMsg}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-2">
+            {nextStatuses.map((s) => {
+              const opt = STATUS_OPTIONS.find((o) => o.value === s)
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => handleStatusChange(s)}
+                  disabled={isUpdating}
+                  className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {opt?.label ?? s}に変更
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 顧客情報 */}
+      <div className="rounded-lg border bg-card p-4 shadow-sm">
+        <h2 className="mb-3 text-sm font-semibold">顧客情報</h2>
+        <dl className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">名前</dt>
+            <dd className="font-medium">{order.user.name ?? '（未設定）'}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">メールアドレス</dt>
+            <dd className="font-medium">{order.user.email}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* 配送先住所 */}
+      {shipping && (
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold">配送先住所</h2>
+          <address className="not-italic text-sm">
+            <p>{shipping.name}</p>
+            <p>〒{shipping.postalCode}</p>
+            <p>
+              {shipping.prefecture}
+              {shipping.city}
+              {shipping.line1}
+              {shipping.line2 ? ` ${shipping.line2}` : ''}
+            </p>
+            {shipping.phone && <p>Tel: {shipping.phone}</p>}
+          </address>
+        </div>
+      )}
+
+      {/* 注文商品 */}
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="p-4 pb-0">
+          <h2 className="text-sm font-semibold">注文商品</h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">商品名</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">単価</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">数量</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">小計</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.items.map((item) => (
+                <tr key={item.id} className="border-b last:border-0">
+                  <td className="px-4 py-3">
+                    <p className="font-medium">{item.product.name}</p>
+                    <p className="text-xs text-muted-foreground font-mono">{item.productId.slice(0, 8)}…</p>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    ¥{item.unitPrice.toLocaleString('ja-JP')}
+                  </td>
+                  <td className="px-4 py-3 text-right">{item.quantity}</td>
+                  <td className="px-4 py-3 text-right font-medium">
+                    ¥{(item.unitPrice * item.quantity).toLocaleString('ja-JP')}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {/* 合計 */}
+        <div className="border-t p-4">
+          {order.coupon && (
+            <div className="mb-2 flex justify-between text-sm text-muted-foreground">
+              <span>クーポン ({order.coupon.code} / {order.coupon.discountPct}%OFF)</span>
+            </div>
+          )}
+          <div className="flex justify-between text-base font-bold">
+            <span>合計</span>
+            <span>¥{order.totalPrice.toLocaleString('ja-JP')}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 注文メタ情報 */}
+      <div className="rounded-lg border bg-card p-4 shadow-sm">
+        <h2 className="mb-3 text-sm font-semibold">注文情報</h2>
+        <dl className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">注文日時</dt>
+            <dd className="font-medium">
+              {new Date(order.createdAt).toLocaleString('ja-JP', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">最終更新</dt>
+            <dd className="font-medium">
+              {new Date(order.updatedAt).toLocaleString('ja-JP', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </dd>
+          </div>
+          {order.stripePaymentIntentId && (
+            <div className="sm:col-span-2">
+              <dt className="text-muted-foreground">Stripe PaymentIntent ID</dt>
+              <dd className="font-mono text-xs">{order.stripePaymentIntentId}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/admin/OrderTable.tsx
+++ b/src/components/features/admin/OrderTable.tsx
@@ -1,0 +1,196 @@
+'use client'
+// 管理画面 注文一覧テーブルコンポーネント
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { Order, OrderItem, Product, User } from '@/generated/prisma/client'
+import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
+import { ADMIN_ORDER_PAGE_SIZE } from '@/constants/admin'
+
+type OrderWithRelations = Order & {
+  user: Pick<User, 'id' | 'email' | 'name'>
+  items: (OrderItem & { product: Product })[]
+}
+
+type Props = {
+  orders: OrderWithRelations[]
+  total: number
+  currentPage: number
+  currentStatus: string
+}
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'すべて' },
+  { value: 'PENDING', label: '未払い' },
+  { value: 'PAID', label: '支払済' },
+  { value: 'SHIPPED', label: '発送済' },
+  { value: 'DELIVERED', label: '配達完了' },
+  { value: 'CANCELLED', label: 'キャンセル' },
+]
+
+export const OrderTable = ({ orders, total, currentPage, currentStatus }: Props) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const totalPages = Math.ceil(total / ADMIN_ORDER_PAGE_SIZE)
+
+  const buildUrl = (page: number, status: string) => {
+    const params = new URLSearchParams()
+    if (status) params.set('status', status)
+    if (page > 1) params.set('page', String(page))
+    const query = params.toString()
+    return `/admin/orders${query ? `?${query}` : ''}`
+  }
+
+  const handleStatusChange = (status: string) => {
+    router.push(buildUrl(1, status))
+  }
+
+  if (orders.length === 0) {
+    return (
+      <div className="space-y-4">
+        {/* ステータスフィルター */}
+        <div className="flex flex-wrap gap-2">
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => handleStatusChange(opt.value)}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                currentStatus === opt.value
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/70'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground">
+          注文がまだありません。
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ステータスフィルター */}
+      <div className="flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => handleStatusChange(opt.value)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              currentStatus === opt.value
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/70'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 件数表示 */}
+      <p className="text-sm text-muted-foreground">
+        全 {total} 件中 {(currentPage - 1) * ADMIN_ORDER_PAGE_SIZE + 1}〜
+        {Math.min(currentPage * ADMIN_ORDER_PAGE_SIZE, total)} 件を表示
+      </p>
+
+      {/* テーブル */}
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">注文ID</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">顧客</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">金額</th>
+                <th className="px-4 py-3 text-center font-medium text-muted-foreground">ステータス</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">注文日時</th>
+                <th className="px-4 py-3 text-center font-medium text-muted-foreground">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((order) => (
+                <tr key={order.id} className="border-b last:border-0 transition-colors hover:bg-muted/30">
+                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                    {order.id.slice(0, 8)}…
+                  </td>
+                  <td className="px-4 py-3">
+                    <p className="font-medium">{order.user.name ?? '（名前未設定）'}</p>
+                    <p className="text-xs text-muted-foreground">{order.user.email}</p>
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium">
+                    ¥{order.totalPrice.toLocaleString('ja-JP')}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        ORDER_STATUS_CLASS[order.status] ?? 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      {ORDER_STATUS_LABEL[order.status] ?? order.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {new Date(order.createdAt).toLocaleString('ja-JP', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <Link
+                      href={`/admin/orders/${order.id}`}
+                      className="rounded px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                    >
+                      詳細
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Link
+            href={buildUrl(currentPage - 1, currentStatus)}
+            aria-label="前のページ"
+            aria-disabled={currentPage <= 1}
+            className={`inline-flex items-center rounded p-1.5 transition-colors ${
+              currentPage <= 1
+                ? 'pointer-events-none text-muted-foreground/40'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            }`}
+          >
+            <ChevronLeft size={18} aria-hidden="true" />
+          </Link>
+          <span className="text-sm text-muted-foreground">
+            {currentPage} / {totalPages}
+          </span>
+          <Link
+            href={buildUrl(currentPage + 1, currentStatus)}
+            aria-label="次のページ"
+            aria-disabled={currentPage >= totalPages}
+            className={`inline-flex items-center rounded p-1.5 transition-colors ${
+              currentPage >= totalPages
+                ? 'pointer-events-none text-muted-foreground/40'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            }`}
+          >
+            <ChevronRight size={18} aria-hidden="true" />
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/admin/OrderTable.tsx
+++ b/src/components/features/admin/OrderTable.tsx
@@ -1,11 +1,10 @@
 'use client'
 // 管理画面 注文一覧テーブルコンポーネント
-import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ADMIN_ORDER_PAGE_SIZE, ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
 import type { Order, OrderItem, Product, User } from '@/generated/prisma/client'
-import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
-import { ADMIN_ORDER_PAGE_SIZE } from '@/constants/admin'
 
 type OrderWithRelations = Order & {
   user: Pick<User, 'id' | 'email' | 'name'>
@@ -30,7 +29,6 @@ const STATUS_OPTIONS = [
 
 export const OrderTable = ({ orders, total, currentPage, currentStatus }: Props) => {
   const router = useRouter()
-  const searchParams = useSearchParams()
 
   const totalPages = Math.ceil(total / ADMIN_ORDER_PAGE_SIZE)
 

--- a/src/components/features/admin/OrderTable.tsx
+++ b/src/components/features/admin/OrderTable.tsx
@@ -164,6 +164,7 @@ export const OrderTable = ({ orders, total, currentPage, currentStatus }: Props)
             href={buildUrl(currentPage - 1, currentStatus)}
             aria-label="前のページ"
             aria-disabled={currentPage <= 1}
+            tabIndex={currentPage <= 1 ? -1 : undefined}
             className={`inline-flex items-center rounded p-1.5 transition-colors ${
               currentPage <= 1
                 ? 'pointer-events-none text-muted-foreground/40'
@@ -179,6 +180,7 @@ export const OrderTable = ({ orders, total, currentPage, currentStatus }: Props)
             href={buildUrl(currentPage + 1, currentStatus)}
             aria-label="次のページ"
             aria-disabled={currentPage >= totalPages}
+            tabIndex={currentPage >= totalPages ? -1 : undefined}
             className={`inline-flex items-center rounded p-1.5 transition-colors ${
               currentPage >= totalPages
                 ? 'pointer-events-none text-muted-foreground/40'

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -1,5 +1,8 @@
 // 管理画面関連定数
 
+// 注文一覧ページのページサイズ
+export const ADMIN_ORDER_PAGE_SIZE = 20
+
 // 注文ステータスの表示ラベル
 export const ORDER_STATUS_LABEL: Record<string, string> = {
   PENDING: '未払い',

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -47,6 +47,14 @@ export const updateOrderStatus = async (id: string, status: OrderStatus) => {
   return prisma.order.update({ where: { id }, data: { status } })
 }
 
+// 注文件数取得（管理画面ページネーション用）
+export const countOrders = async (params: { status?: OrderStatus } = {}) => {
+  const { status } = params
+  return prisma.order.count({
+    where: { ...(status ? { status } : {}) },
+  })
+}
+
 // 追加: PaymentIntent ID を注文に紐付ける
 export const updateOrderStripeId = async (id: string, stripePaymentIntentId: string) => {
   return prisma.order.update({ where: { id }, data: { stripePaymentIntentId } })


### PR DESCRIPTION
## 概要
Issue #27 に対応。管理者が注文の一覧を確認し、ステータスを変更できる管理画面を実装。

## 実装内容

### APIエンドポイント
- `GET /api/admin/orders` — 注文一覧取得（ステータスフィルター・ページネーション）
- `GET /api/admin/orders/:id` — 注文詳細取得
- `PATCH /api/admin/orders/:id` — 注文ステータス変更

### ページ
- `/admin/orders` — 注文一覧ページ（ステータスフィルター・ページネーション付き）
- `/admin/orders/:id` — 注文詳細ページ（顧客情報・商品明細・ステータス変更）

### コンポーネント
- `OrderTable.tsx` — 注文一覧テーブル（Client Component）
- `OrderDetail.tsx` — 注文詳細・ステータス変更（Client Component）

### その他変更
- `src/lib/db/orders.ts` — `countOrders` 関数追加（ページネーション用）
- `src/constants/admin.ts` — `ADMIN_ORDER_PAGE_SIZE` 定数追加

## セキュリティ
- 全エンドポイントに `requireAdmin()` による管理者ロールチェックを実装
- キャンセル済み注文は変更不可
- ステータス値は Zod スキーマで検証

## 証跡
- `/admin/orders` アクセス時、未ログインの場合は `/login` へリダイレクト（認証ガード動作確認）
- ビルド成功: `✓ Compiled successfully`