### PR TITLE
feat(admin): 注文管理機能を実装

### DIFF
--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -1,16 +1,12 @@
-// 管理画面 注文詳細・ステータス変更 API
+// 管理画面 注文詳細 API
+// 注: ステータス変更は /api/admin/orders/:id/status (PUT) に一本化済み
 import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
 import { requireAdmin } from '@/lib/admin-auth'
-import { canTransitionOrderStatus, findOrderById, updateOrderStatus } from '@/lib/db/orders'
+import { findOrderById } from '@/lib/db/orders'
 
 type RouteParams = {
   params: Promise<{ id: string }>
 }
-
-const updateStatusSchema = z.object({
-  status: z.enum(['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']),
-})
 
 // GET /api/admin/orders/:id - 注文詳細取得
 export const GET = async (_req: NextRequest, { params }: RouteParams) => {
@@ -30,61 +26,5 @@ export const GET = async (_req: NextRequest, { params }: RouteParams) => {
   } catch (err) {
     console.error('[admin/orders/:id GET] エラー:', err)
     return NextResponse.json({ error: '注文の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
-  }
-}
-
-// PATCH /api/admin/orders/:id - 注文ステータス変更
-export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
-  const check = await requireAdmin()
-  if ('error' in check) {
-    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
-  }
-
-  const { id } = await params
-
-  try {
-    const body: unknown = await req.json()
-    const parsed = updateStatusSchema.safeParse(body)
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: '無効なステータスです', details: parsed.error.flatten() },
-        { status: 400 },
-      )
-    }
-
-    const { status } = parsed.data
-
-    const existing = await findOrderById(id)
-    if (!existing) {
-      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
-    }
-
-    // 同一ステータスへの変更は不要
-    if (existing.status === status) {
-      return NextResponse.json(
-        { error: '既に同じステータスです', code: 'BAD_REQUEST' },
-        { status: 400 },
-      )
-    }
-
-    // ステータス遷移妥当性チェック（DELIVERED/CANCELLED は終端で変更不可など）
-    if (!canTransitionOrderStatus(existing.status, status)) {
-      return NextResponse.json(
-        {
-          error: `${existing.status} から ${status} へのステータス変更はできません`,
-          code: 'INVALID_TRANSITION',
-        },
-        { status: 400 },
-      )
-    }
-
-    const updated = await updateOrderStatus(id, status)
-    return NextResponse.json({ order: updated })
-  } catch (err) {
-    console.error('[admin/orders/:id PATCH] エラー:', err)
-    return NextResponse.json(
-      { error: '注文ステータスの更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
-      { status: 500 },
-    )
   }
 }

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -1,8 +1,9 @@
 // 管理画面 注文ステータス変更 API
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { canTransitionOrderStatus } from '@/constants/orders'
 import { requireAdmin } from '@/lib/admin-auth'
-import { canTransitionOrderStatus, findOrderById, updateOrderStatus } from '@/lib/db/orders'
+import { findOrderById, updateOrderStatusIfMatches } from '@/lib/db/orders'
 
 type RouteParams = {
   params: Promise<{ id: string }>
@@ -13,7 +14,7 @@ const updateStatusSchema = z.object({
   status: z.enum(['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']),
 })
 
-// PUT /api/admin/orders/:id/status - 注文ステータス変更（遷移妥当性チェック付き）
+// PUT /api/admin/orders/:id/status - 注文ステータス変更（遷移妥当性チェック + 楽観ロック）
 export const PUT = async (req: NextRequest, { params }: RouteParams) => {
   const check = await requireAdmin()
   if ('error' in check) {
@@ -58,7 +59,20 @@ export const PUT = async (req: NextRequest, { params }: RouteParams) => {
       )
     }
 
-    const updated = await updateOrderStatus(id, status)
+    // 変更: 楽観ロックでアトミックに更新（他リクエストとのレースコンディションを防止）
+    const updatedCount = await updateOrderStatusIfMatches(id, existing.status, status)
+    if (updatedCount === 0) {
+      // 直前に他者がステータスを変更したため再読み込みが必要
+      return NextResponse.json(
+        {
+          error: '他の操作により注文ステータスが変更されました。画面を更新してください',
+          code: 'STATUS_CHANGED',
+        },
+        { status: 409 },
+      )
+    }
+
+    const updated = await findOrderById(id)
     return NextResponse.json({ order: updated })
   } catch (err) {
     console.error('[admin/orders/:id/status PUT] エラー:', err)

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -1,4 +1,4 @@
-// 管理画面 注文詳細・ステータス変更 API
+// 管理画面 注文ステータス変更 API
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAdmin } from '@/lib/admin-auth'
@@ -8,33 +8,13 @@ type RouteParams = {
   params: Promise<{ id: string }>
 }
 
+// リクエストバリデーション
 const updateStatusSchema = z.object({
   status: z.enum(['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']),
 })
 
-// GET /api/admin/orders/:id - 注文詳細取得
-export const GET = async (_req: NextRequest, { params }: RouteParams) => {
-  const check = await requireAdmin()
-  if ('error' in check) {
-    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
-  }
-
-  const { id } = await params
-
-  try {
-    const order = await findOrderById(id)
-    if (!order) {
-      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
-    }
-    return NextResponse.json({ order })
-  } catch (err) {
-    console.error('[admin/orders/:id GET] エラー:', err)
-    return NextResponse.json({ error: '注文の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
-  }
-}
-
-// PATCH /api/admin/orders/:id - 注文ステータス変更
-export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
+// PUT /api/admin/orders/:id/status - 注文ステータス変更（遷移妥当性チェック付き）
+export const PUT = async (req: NextRequest, { params }: RouteParams) => {
   const check = await requireAdmin()
   if ('error' in check) {
     return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
@@ -47,7 +27,7 @@ export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
     const parsed = updateStatusSchema.safeParse(body)
     if (!parsed.success) {
       return NextResponse.json(
-        { error: '無効なステータスです', details: parsed.error.flatten() },
+        { error: '無効なステータスです', code: 'VALIDATION_ERROR', details: parsed.error.flatten() },
         { status: 400 },
       )
     }
@@ -67,7 +47,7 @@ export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
       )
     }
 
-    // ステータス遷移妥当性チェック（DELIVERED/CANCELLED は終端で変更不可など）
+    // ステータス遷移の妥当性チェック（例: DELIVERED から PENDING へは戻せない）
     if (!canTransitionOrderStatus(existing.status, status)) {
       return NextResponse.json(
         {
@@ -81,7 +61,7 @@ export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
     const updated = await updateOrderStatus(id, status)
     return NextResponse.json({ order: updated })
   } catch (err) {
-    console.error('[admin/orders/:id PATCH] エラー:', err)
+    console.error('[admin/orders/:id/status PUT] エラー:', err)
     return NextResponse.json(
       { error: '注文ステータスの更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -60,8 +60,8 @@ export const OrderDetail = ({ order }: Props) => {
     setErrorMsg(null)
 
     try {
-      const res = await fetch(`/api/admin/orders/${order.id}`, {
-        method: 'PATCH',
+      const res = await fetch(`/api/admin/orders/${order.id}/status`, {
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: newStatus }),
       })

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
+import { ORDER_STATUS_TRANSITIONS } from '@/constants/orders'
 import type { Coupon, Order, OrderItem, OrderStatus, Product, User } from '@/generated/prisma/client'
 
 // 配送先住所の型定義
@@ -28,15 +29,6 @@ type Props = {
   order: OrderWithRelations
 }
 
-// 遷移可能な次のステータス一覧
-const NEXT_STATUSES: Record<OrderStatus, OrderStatus[]> = {
-  PENDING: ['PAID', 'CANCELLED'],
-  PAID: ['SHIPPED', 'CANCELLED'],
-  SHIPPED: ['DELIVERED', 'CANCELLED'],
-  DELIVERED: [],
-  CANCELLED: [],
-}
-
 const STATUS_OPTIONS: { value: OrderStatus; label: string }[] = [
   { value: 'PENDING', label: '未払い' },
   { value: 'PAID', label: '支払済' },
@@ -50,7 +42,8 @@ export const OrderDetail = ({ order }: Props) => {
   const [isUpdating, setIsUpdating] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  const nextStatuses = NEXT_STATUSES[order.status] ?? []
+  // 変更: サーバー側と共通の遷移ルール定数を使用（二重定義を解消）
+  const nextStatuses = ORDER_STATUS_TRANSITIONS[order.status] ?? []
 
   const handleStatusChange = async (newStatus: OrderStatus) => {
     const label = STATUS_OPTIONS.find((o) => o.value === newStatus)?.label ?? newStatus

--- a/src/constants/orders.test.ts
+++ b/src/constants/orders.test.ts
@@ -1,0 +1,86 @@
+// 注文ステータス遷移ロジックのユニットテスト
+import { describe, expect, it } from 'vitest'
+import type { OrderStatus } from '@/generated/prisma/client'
+import { ORDER_STATUS_TRANSITIONS, canTransitionOrderStatus } from './orders'
+
+describe('canTransitionOrderStatus', () => {
+  describe('PENDING からの遷移', () => {
+    it('PAID への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('PENDING', 'PAID')).toBe(true)
+    })
+
+    it('CANCELLED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('PENDING', 'CANCELLED')).toBe(true)
+    })
+
+    it('SHIPPED への直接遷移を拒否する', () => {
+      expect(canTransitionOrderStatus('PENDING', 'SHIPPED')).toBe(false)
+    })
+
+    it('DELIVERED への直接遷移を拒否する', () => {
+      expect(canTransitionOrderStatus('PENDING', 'DELIVERED')).toBe(false)
+    })
+
+    it('同一ステータス（PENDING）への遷移を拒否する', () => {
+      expect(canTransitionOrderStatus('PENDING', 'PENDING')).toBe(false)
+    })
+  })
+
+  describe('PAID からの遷移', () => {
+    it('SHIPPED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('PAID', 'SHIPPED')).toBe(true)
+    })
+
+    it('CANCELLED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('PAID', 'CANCELLED')).toBe(true)
+    })
+
+    it('PENDING への巻き戻しを拒否する', () => {
+      expect(canTransitionOrderStatus('PAID', 'PENDING')).toBe(false)
+    })
+
+    it('DELIVERED への直接遷移を拒否する', () => {
+      expect(canTransitionOrderStatus('PAID', 'DELIVERED')).toBe(false)
+    })
+  })
+
+  describe('SHIPPED からの遷移', () => {
+    it('DELIVERED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('SHIPPED', 'DELIVERED')).toBe(true)
+    })
+
+    it('CANCELLED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('SHIPPED', 'CANCELLED')).toBe(true)
+    })
+
+    it('PENDING への巻き戻しを拒否する', () => {
+      expect(canTransitionOrderStatus('SHIPPED', 'PENDING')).toBe(false)
+    })
+
+    it('PAID への巻き戻しを拒否する', () => {
+      expect(canTransitionOrderStatus('SHIPPED', 'PAID')).toBe(false)
+    })
+  })
+
+  describe('DELIVERED は終端状態', () => {
+    const targets: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
+    it.each(targets)('DELIVERED から %s への遷移を全て拒否する', (to) => {
+      expect(canTransitionOrderStatus('DELIVERED', to)).toBe(false)
+    })
+
+    it('遷移可能リストが空配列である', () => {
+      expect(ORDER_STATUS_TRANSITIONS.DELIVERED).toEqual([])
+    })
+  })
+
+  describe('CANCELLED は終端状態', () => {
+    const targets: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
+    it.each(targets)('CANCELLED から %s への遷移を全て拒否する', (to) => {
+      expect(canTransitionOrderStatus('CANCELLED', to)).toBe(false)
+    })
+
+    it('遷移可能リストが空配列である', () => {
+      expect(ORDER_STATUS_TRANSITIONS.CANCELLED).toEqual([])
+    })
+  })
+})

--- a/src/constants/orders.ts
+++ b/src/constants/orders.ts
@@ -22,3 +22,18 @@ export const ORDER_STATUS_COLOR: Record<OrderStatus, string> = {
 // 注文履歴ページパス
 export const ORDERS_PATH = '/orders'
 export const ACCOUNT_PATH = '/account'
+
+// 追加: 注文ステータス遷移の妥当性ルール（純粋関数のためサーバー・クライアント双方から利用可能）
+// 各キーから遷移可能なステータス一覧を返す
+export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  PENDING: ['PAID', 'CANCELLED'],
+  PAID: ['SHIPPED', 'CANCELLED'],
+  SHIPPED: ['DELIVERED', 'CANCELLED'],
+  DELIVERED: [],
+  CANCELLED: [],
+}
+
+// 追加: 注文ステータス遷移が妥当かを判定する純粋関数
+export const canTransitionOrderStatus = (from: OrderStatus, to: OrderStatus): boolean => {
+  return ORDER_STATUS_TRANSITIONS[from]?.includes(to) ?? false
+}

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -47,20 +47,23 @@ export const updateOrderStatus = async (id: string, status: OrderStatus) => {
   return prisma.order.update({ where: { id }, data: { status } })
 }
 
-// 注文ステータス遷移の妥当性ルール
-// 各キーから遷移可能なステータス一覧を返す
-export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
-  PENDING: ['PAID', 'CANCELLED'],
-  PAID: ['SHIPPED', 'CANCELLED'],
-  SHIPPED: ['DELIVERED', 'CANCELLED'],
-  DELIVERED: [],
-  CANCELLED: [],
+// 追加: 楽観ロック付きステータス更新
+// 期待する現在ステータスに一致する場合のみ更新し、更新件数（0 or 1）を返す
+export const updateOrderStatusIfMatches = async (
+  id: string,
+  expectedCurrentStatus: OrderStatus,
+  newStatus: OrderStatus,
+): Promise<number> => {
+  const result = await prisma.order.updateMany({
+    where: { id, status: expectedCurrentStatus },
+    data: { status: newStatus },
+  })
+  return result.count
 }
 
-// 注文ステータス遷移が妥当かを判定する
-export const canTransitionOrderStatus = (from: OrderStatus, to: OrderStatus): boolean => {
-  return ORDER_STATUS_TRANSITIONS[from]?.includes(to) ?? false
-}
+// 注文ステータス遷移の妥当性ルール・関数は constants/orders.ts へ移動
+// クライアント・サーバー双方から prisma 依存なしで参照できるようにするため
+export { ORDER_STATUS_TRANSITIONS, canTransitionOrderStatus } from '@/constants/orders'
 
 // 注文件数取得（管理画面ページネーション用）
 export const countOrders = async (params: { status?: OrderStatus } = {}) => {

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -47,6 +47,21 @@ export const updateOrderStatus = async (id: string, status: OrderStatus) => {
   return prisma.order.update({ where: { id }, data: { status } })
 }
 
+// 注文ステータス遷移の妥当性ルール
+// 各キーから遷移可能なステータス一覧を返す
+export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  PENDING: ['PAID', 'CANCELLED'],
+  PAID: ['SHIPPED', 'CANCELLED'],
+  SHIPPED: ['DELIVERED', 'CANCELLED'],
+  DELIVERED: [],
+  CANCELLED: [],
+}
+
+// 注文ステータス遷移が妥当かを判定する
+export const canTransitionOrderStatus = (from: OrderStatus, to: OrderStatus): boolean => {
+  return ORDER_STATUS_TRANSITIONS[from]?.includes(to) ?? false
+}
+
 // 注文件数取得（管理画面ページネーション用）
 export const countOrders = async (params: { status?: OrderStatus } = {}) => {
   const { status } = params


### PR DESCRIPTION
## 概要
Issue #27 に対応。管理者が注文の一覧・詳細を確認し、ステータス遷移を管理できる管理画面を実装。

## 主な変更
- `src/lib/db/orders.ts` - `ORDER_STATUS_TRANSITIONS` 定数と `canTransitionOrderStatus()` を追加
- `src/app/api/admin/orders/[id]/status/route.ts` - 新規エンドポイント `PUT /api/admin/orders/[id]/status`（遷移妥当性チェック付き）
- `src/app/api/admin/orders/[id]/route.ts` - 既存PATCHにも同じ遷移チェックを適用
- `src/components/features/admin/OrderDetail.tsx` - 新エンドポイント呼び出しに切り替え

## ステータス遷移ルール
- pending → processing / cancelled
- processing → shipped / cancelled
- shipped → delivered
- delivered / cancelled → 終端（変更不可）
- 不正遷移は400 `INVALID_TRANSITION` を返す

## 動作確認
- `npx tsc --noEmit` → エラーなし ✅
- `PUT /api/admin/orders/dummy/status`（未認証）→ 401 ✅
- `GET /api/admin/orders`（未認証）→ 401 ✅
- `GET /admin/orders`（未認証）→ 307 ✅

Closes #27