### PR TITLE
feat(email): 注文確認・発送通知メールを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.74.0",
+    "resend": "^6.12.2",
     "server-only": "^0.0.1",
     "stripe": "^22.1.0",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-hook-form:
         specifier: ^7.74.0
         version: 7.74.0(react@18.3.1)
+      resend:
+        specifier: ^6.12.2
+        version: 6.12.2
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -718,6 +721,9 @@ packages:
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1591,6 +1597,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2392,6 +2401,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -2571,6 +2583,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2710,6 +2731,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -2809,6 +2833,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -2934,6 +2961,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -3609,6 +3640,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4628,6 +4661,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -5396,6 +5431,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
@@ -5566,6 +5603,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.12.2:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -5728,6 +5770,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   std-env@4.1.0: {}
@@ -5841,6 +5888,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -6015,6 +6067,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import { canTransitionOrderStatus } from '@/constants/orders'
 import { requireAdmin } from '@/lib/admin-auth'
 import { findOrderById, updateOrderStatusIfMatches } from '@/lib/db/orders'
+import { sendShipmentNotificationEmail } from '@/lib/email/sendShipmentNotification' // 追加
+import type { ShippingAddress } from '@/constants/checkout' // 追加
 
 type RouteParams = {
   params: Promise<{ id: string }>
@@ -73,6 +75,18 @@ export const PUT = async (req: NextRequest, { params }: RouteParams) => {
     }
 
     const updated = await findOrderById(id)
+
+    // 追加: SHIPPED へ変更された場合は発送通知メールを送信（失敗してもステータス変更は成功扱い）
+    if (status === 'SHIPPED' && updated?.user?.email && updated.shippingAddress) {
+      await sendShipmentNotificationEmail({
+        to: updated.user.email,
+        order: {
+          id: updated.id,
+          shippingAddress: updated.shippingAddress as unknown as ShippingAddress,
+        },
+      })
+    }
+
     return NextResponse.json({ order: updated })
   } catch (err) {
     console.error('[admin/orders/:id/status PUT] エラー:', err)

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -5,7 +5,7 @@ import { canTransitionOrderStatus } from '@/constants/orders'
 import { requireAdmin } from '@/lib/admin-auth'
 import { findOrderById, updateOrderStatusIfMatches } from '@/lib/db/orders'
 import { sendShipmentNotificationEmail } from '@/lib/email/sendShipmentNotification' // 追加
-import type { ShippingAddress } from '@/constants/checkout' // 追加
+import { shippingAddressSchema } from '@/lib/validators/order' // 変更: ダブルキャスト解消のため Zod パースを使用
 
 type RouteParams = {
   params: Promise<{ id: string }>
@@ -78,13 +78,19 @@ export const PUT = async (req: NextRequest, { params }: RouteParams) => {
 
     // 追加: SHIPPED へ変更された場合は発送通知メールを送信（失敗してもステータス変更は成功扱い）
     if (status === 'SHIPPED' && updated?.user?.email && updated.shippingAddress) {
-      await sendShipmentNotificationEmail({
-        to: updated.user.email,
-        order: {
-          id: updated.id,
-          shippingAddress: updated.shippingAddress as unknown as ShippingAddress,
-        },
-      })
+      // 変更: ダブルキャストではなく Zod でパースして型安全に扱う
+      const addressParsed = shippingAddressSchema.safeParse(updated.shippingAddress)
+      if (addressParsed.success) {
+        await sendShipmentNotificationEmail({
+          to: updated.user.email,
+          order: {
+            id: updated.id,
+            shippingAddress: addressParsed.data,
+          },
+        })
+      } else {
+        console.error('[admin/orders/:id/status PUT] shippingAddress パース失敗。メール送信をスキップ:', addressParsed.error.flatten())
+      }
     }
 
     return NextResponse.json({ order: updated })

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -6,6 +6,7 @@ import { validateCartItems } from '@/lib/db/products'
 import { findCouponByCode, incrementCouponUsedCountAtomic } from '@/lib/db/coupons' // 変更
 import type { Prisma } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
+import { sendOrderConfirmationEmail } from '@/lib/email/sendOrderConfirmation' // 追加
 
 type CartItemInput = {
   id: string
@@ -120,6 +121,23 @@ export const POST = async (req: NextRequest) => {
         })),
       },
     })
+
+    // 追加: 注文確認メール送信（失敗してもorderレスポンスは正常に返す）
+    if (session.user.email) {
+      await sendOrderConfirmationEmail({
+        to: session.user.email,
+        order: {
+          id: order.id,
+          totalPrice: order.totalPrice,
+          shippingAddress,
+        },
+        items: productData.map(({ product, quantity }) => ({
+          productName: product.name,
+          quantity,
+          unitPrice: product.price,
+        })),
+      })
+    }
 
     return NextResponse.json({ orderId: order.id }, { status: 201 })
   } catch (err) {

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -1,0 +1,9 @@
+// メール送信関連の定数
+// 送信元アドレス（実際のドメインは将来環境変数化予定）
+export const EMAIL_FROM = 'noreply@example.com'
+
+// メール件名
+export const EMAIL_SUBJECTS = {
+  ORDER_CONFIRMATION: 'ご注文ありがとうございます',
+  SHIPMENT_NOTIFICATION: '商品を発送しました',
+} as const

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -1,6 +1,5 @@
 // メール送信関連の定数
-// 送信元アドレス（実際のドメインは将来環境変数化予定）
-export const EMAIL_FROM = 'noreply@example.com'
+// 変更: 送信元アドレスは src/env.ts の EMAIL_FROM を参照（ハードコード解消）
 
 // メール件名
 export const EMAIL_SUBJECTS = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,6 +22,8 @@ const envSchema = z.object({
 
   // Resend（メール送信）
   RESEND_API_KEY: z.string().min(1),
+  // 追加: メール送信元アドレス（開発時のデフォルトは Resend のサンドボックス）
+  EMAIL_FROM: z.string().min(1).default('onboarding@resend.dev'),
 
   // アプリ設定
   NEXT_PUBLIC_APP_URL: z.string().min(1),

--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -1,0 +1,6 @@
+import 'server-only' // クライアントバンドルへの混入防止
+import { Resend } from 'resend'
+import { env } from '@/env'
+
+// Resend クライアント（サーバー専用）
+export const resend = new Resend(env.RESEND_API_KEY)

--- a/src/lib/email/sendOrderConfirmation.ts
+++ b/src/lib/email/sendOrderConfirmation.ts
@@ -1,0 +1,35 @@
+import 'server-only'
+import { resend } from '@/lib/email/client'
+import { EMAIL_FROM, EMAIL_SUBJECTS } from '@/constants/email'
+import {
+  renderOrderConfirmationHtml,
+  type OrderConfirmationItem,
+  type OrderConfirmationOrder,
+} from '@/lib/email/templates/orderConfirmation'
+
+// 戻り値型
+type SendResult = { success: boolean; error?: string }
+
+// 注文確認メール送信関数
+// 失敗時もthrowせず、注文処理本体に影響を与えない
+export const sendOrderConfirmationEmail = async (params: {
+  to: string
+  order: OrderConfirmationOrder
+  items: OrderConfirmationItem[]
+}): Promise<SendResult> => {
+  const { to, order, items } = params
+  try {
+    const html = renderOrderConfirmationHtml(order, items)
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to,
+      subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[sendOrderConfirmationEmail] 送信失敗:', err)
+    return { success: false, error: message }
+  }
+}

--- a/src/lib/email/sendOrderConfirmation.ts
+++ b/src/lib/email/sendOrderConfirmation.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { resend } from '@/lib/email/client'
-import { EMAIL_FROM, EMAIL_SUBJECTS } from '@/constants/email'
+import { env } from '@/env' // 変更: 送信元アドレスを環境変数から取得
+import { EMAIL_SUBJECTS } from '@/constants/email'
 import {
   renderOrderConfirmationHtml,
   type OrderConfirmationItem,
@@ -21,7 +22,7 @@ export const sendOrderConfirmationEmail = async (params: {
   try {
     const html = renderOrderConfirmationHtml(order, items)
     await resend.emails.send({
-      from: EMAIL_FROM,
+      from: env.EMAIL_FROM, // 変更: ハードコード解消
       to,
       subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
       html,

--- a/src/lib/email/sendShipmentNotification.ts
+++ b/src/lib/email/sendShipmentNotification.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { resend } from '@/lib/email/client'
-import { EMAIL_FROM, EMAIL_SUBJECTS } from '@/constants/email'
+import { env } from '@/env' // 変更: 送信元アドレスを環境変数から取得
+import { EMAIL_SUBJECTS } from '@/constants/email'
 import {
   renderShipmentNotificationHtml,
   type ShipmentNotificationOrder,
@@ -19,7 +20,7 @@ export const sendShipmentNotificationEmail = async (params: {
   try {
     const html = renderShipmentNotificationHtml(order)
     await resend.emails.send({
-      from: EMAIL_FROM,
+      from: env.EMAIL_FROM, // 変更: ハードコード解消
       to,
       subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
       html,

--- a/src/lib/email/sendShipmentNotification.ts
+++ b/src/lib/email/sendShipmentNotification.ts
@@ -1,0 +1,33 @@
+import 'server-only'
+import { resend } from '@/lib/email/client'
+import { EMAIL_FROM, EMAIL_SUBJECTS } from '@/constants/email'
+import {
+  renderShipmentNotificationHtml,
+  type ShipmentNotificationOrder,
+} from '@/lib/email/templates/shipmentNotification'
+
+// 戻り値型
+type SendResult = { success: boolean; error?: string }
+
+// 発送通知メール送信関数
+// 失敗時もthrowせず、注文ステータス変更処理本体に影響を与えない
+export const sendShipmentNotificationEmail = async (params: {
+  to: string
+  order: ShipmentNotificationOrder
+}): Promise<SendResult> => {
+  const { to, order } = params
+  try {
+    const html = renderShipmentNotificationHtml(order)
+    await resend.emails.send({
+      from: EMAIL_FROM,
+      to,
+      subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[sendShipmentNotificationEmail] 送信失敗:', err)
+    return { success: false, error: message }
+  }
+}

--- a/src/lib/email/templates/orderConfirmation.test.ts
+++ b/src/lib/email/templates/orderConfirmation.test.ts
@@ -1,0 +1,33 @@
+// 注文確認メールテンプレートのユニットテスト
+import { describe, expect, it } from 'vitest'
+import { renderOrderConfirmationHtml } from './orderConfirmation'
+
+const baseAddress = {
+  name: '山田太郎',
+  postalCode: '100-0001',
+  prefecture: '東京都',
+  city: '千代田区',
+  addressLine1: '千代田1-1',
+  phone: '03-0000-0000',
+}
+
+describe('renderOrderConfirmationHtml', () => {
+  it('注文番号・合計金額・商品名がHTMLに含まれる', () => {
+    const html = renderOrderConfirmationHtml(
+      { id: 'order_123', totalPrice: 12345, shippingAddress: baseAddress },
+      [{ productName: 'テスト商品', quantity: 2, unitPrice: 5000 }],
+    )
+    expect(html).toContain('order_123')
+    expect(html).toContain('¥12,345')
+    expect(html).toContain('テスト商品')
+  })
+
+  it('商品名に <script> が含まれていてもエスケープされる', () => {
+    const html = renderOrderConfirmationHtml(
+      { id: 'order_xss', totalPrice: 100, shippingAddress: baseAddress },
+      [{ productName: '<script>alert(1)</script>', quantity: 1, unitPrice: 100 }],
+    )
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})

--- a/src/lib/email/templates/orderConfirmation.ts
+++ b/src/lib/email/templates/orderConfirmation.ts
@@ -1,5 +1,6 @@
 // 注文確認メールHTMLテンプレート
 import type { ShippingAddress } from '@/constants/checkout'
+import { escapeHtml } from '@/lib/email/utils' // 変更: 共通ユーティリティに集約
 
 // テンプレートに渡す注文情報の型
 export type OrderConfirmationOrder = {
@@ -17,15 +18,6 @@ export type OrderConfirmationItem = {
 
 // 数値を日本円表記にフォーマット
 const formatJpy = (value: number): string => `¥${value.toLocaleString('ja-JP')}`
-
-// HTMLエスケープ（XSS対策）
-const escapeHtml = (str: string): string =>
-  str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
 
 // 注文確認メールのHTMLを生成する純粋関数
 export const renderOrderConfirmationHtml = (

--- a/src/lib/email/templates/orderConfirmation.ts
+++ b/src/lib/email/templates/orderConfirmation.ts
@@ -1,0 +1,86 @@
+// 注文確認メールHTMLテンプレート
+import type { ShippingAddress } from '@/constants/checkout'
+
+// テンプレートに渡す注文情報の型
+export type OrderConfirmationOrder = {
+  id: string
+  totalPrice: number
+  shippingAddress: ShippingAddress
+}
+
+// 注文明細の型
+export type OrderConfirmationItem = {
+  productName: string
+  quantity: number
+  unitPrice: number
+}
+
+// 数値を日本円表記にフォーマット
+const formatJpy = (value: number): string => `¥${value.toLocaleString('ja-JP')}`
+
+// HTMLエスケープ（XSS対策）
+const escapeHtml = (str: string): string =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+// 注文確認メールのHTMLを生成する純粋関数
+export const renderOrderConfirmationHtml = (
+  order: OrderConfirmationOrder,
+  items: OrderConfirmationItem[],
+): string => {
+  const itemsHtml = items
+    .map(
+      (item) => `
+        <tr>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb;">${escapeHtml(item.productName)}</td>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:center;">${item.quantity}</td>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">${formatJpy(item.unitPrice)}</td>
+          <td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">${formatJpy(item.unitPrice * item.quantity)}</td>
+        </tr>`,
+    )
+    .join('')
+
+  const addr = order.shippingAddress
+  const addressHtml = `
+    ${escapeHtml(addr.name)}<br/>
+    〒${escapeHtml(addr.postalCode)}<br/>
+    ${escapeHtml(addr.prefecture)}${escapeHtml(addr.city)}${escapeHtml(addr.addressLine1)}${addr.addressLine2 ? escapeHtml(addr.addressLine2) : ''}<br/>
+    TEL: ${escapeHtml(addr.phone)}
+  `
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
+    <div style="max-width:600px;margin:0 auto;background-color:#ffffff;padding:32px;border-radius:8px;">
+      <h1 style="font-size:20px;margin:0 0 16px;">ご注文ありがとうございます</h1>
+      <p style="margin:0 0 16px;">この度はご注文いただき誠にありがとうございます。以下の内容で承りました。</p>
+      <p style="margin:0 0 24px;"><strong>注文番号:</strong> ${escapeHtml(order.id)}</p>
+
+      <h2 style="font-size:16px;margin:24px 0 8px;">ご注文内容</h2>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;">
+        <thead>
+          <tr style="background-color:#f3f4f6;">
+            <th style="padding:8px;text-align:left;">商品名</th>
+            <th style="padding:8px;text-align:center;">数量</th>
+            <th style="padding:8px;text-align:right;">単価</th>
+            <th style="padding:8px;text-align:right;">小計</th>
+          </tr>
+        </thead>
+        <tbody>${itemsHtml}</tbody>
+      </table>
+
+      <p style="text-align:right;margin:16px 0 0;font-size:16px;"><strong>合計金額: ${formatJpy(order.totalPrice)}（税込）</strong></p>
+
+      <h2 style="font-size:16px;margin:24px 0 8px;">配送先</h2>
+      <p style="margin:0;line-height:1.6;">${addressHtml}</p>
+
+      <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
+      <p style="font-size:12px;color:#6b7280;margin:0;">本メールは自動送信されています。お問い合わせはサポートまでご連絡ください。</p>
+    </div>
+  </body>
+</html>`
+}

--- a/src/lib/email/templates/shipmentNotification.ts
+++ b/src/lib/email/templates/shipmentNotification.ts
@@ -1,20 +1,12 @@
 // 発送通知メールHTMLテンプレート
 import type { ShippingAddress } from '@/constants/checkout'
+import { escapeHtml } from '@/lib/email/utils' // 変更: 共通ユーティリティに集約
 
 // テンプレートに渡す注文情報の型
 export type ShipmentNotificationOrder = {
   id: string
   shippingAddress: ShippingAddress
 }
-
-// HTMLエスケープ（XSS対策）
-const escapeHtml = (str: string): string =>
-  str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
 
 // 発送通知メールのHTMLを生成する純粋関数
 export const renderShipmentNotificationHtml = (order: ShipmentNotificationOrder): string => {

--- a/src/lib/email/templates/shipmentNotification.ts
+++ b/src/lib/email/templates/shipmentNotification.ts
@@ -1,0 +1,45 @@
+// 発送通知メールHTMLテンプレート
+import type { ShippingAddress } from '@/constants/checkout'
+
+// テンプレートに渡す注文情報の型
+export type ShipmentNotificationOrder = {
+  id: string
+  shippingAddress: ShippingAddress
+}
+
+// HTMLエスケープ（XSS対策）
+const escapeHtml = (str: string): string =>
+  str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+// 発送通知メールのHTMLを生成する純粋関数
+export const renderShipmentNotificationHtml = (order: ShipmentNotificationOrder): string => {
+  const addr = order.shippingAddress
+  const addressHtml = `
+    ${escapeHtml(addr.name)}<br/>
+    〒${escapeHtml(addr.postalCode)}<br/>
+    ${escapeHtml(addr.prefecture)}${escapeHtml(addr.city)}${escapeHtml(addr.addressLine1)}${addr.addressLine2 ? escapeHtml(addr.addressLine2) : ''}<br/>
+    TEL: ${escapeHtml(addr.phone)}
+  `
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
+    <div style="max-width:600px;margin:0 auto;background-color:#ffffff;padding:32px;border-radius:8px;">
+      <h1 style="font-size:20px;margin:0 0 16px;">商品を発送しました</h1>
+      <p style="margin:0 0 16px;">ご注文の商品を発送しましたのでお知らせします。到着まで今しばらくお待ちください。</p>
+      <p style="margin:0 0 24px;"><strong>注文番号:</strong> ${escapeHtml(order.id)}</p>
+
+      <h2 style="font-size:16px;margin:24px 0 8px;">配送先</h2>
+      <p style="margin:0;line-height:1.6;">${addressHtml}</p>
+
+      <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
+      <p style="font-size:12px;color:#6b7280;margin:0;">本メールは自動送信されています。お問い合わせはサポートまでご連絡ください。</p>
+    </div>
+  </body>
+</html>`
+}

--- a/src/lib/email/utils.test.ts
+++ b/src/lib/email/utils.test.ts
@@ -1,0 +1,38 @@
+// メールユーティリティのユニットテスト
+import { describe, expect, it } from 'vitest'
+import { escapeHtml } from './utils'
+
+describe('escapeHtml', () => {
+  it('通常の文字列はそのまま返す', () => {
+    expect(escapeHtml('こんにちは Hello 123')).toBe('こんにちは Hello 123')
+  })
+
+  it('空文字を渡すと空文字が返る', () => {
+    expect(escapeHtml('')).toBe('')
+  })
+
+  it('<script>タグをエスケープする', () => {
+    expect(escapeHtml('<script>alert("x")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;',
+    )
+  })
+
+  it('& < > " \' を個別にエスケープする', () => {
+    expect(escapeHtml('&')).toBe('&amp;')
+    expect(escapeHtml('<')).toBe('&lt;')
+    expect(escapeHtml('>')).toBe('&gt;')
+    expect(escapeHtml('"')).toBe('&quot;')
+    expect(escapeHtml("'")).toBe('&#39;')
+  })
+
+  it('&は最初に1度だけ置換される（二重エスケープしない）', () => {
+    // 入力 "&lt;" が "&amp;lt;" に変換されることを確認（&のみが置換対象）
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;')
+  })
+
+  it('複数の特殊文字が混ざった文字列を全てエスケープする', () => {
+    expect(escapeHtml(`Tom & Jerry's "show" <b>`)).toBe(
+      'Tom &amp; Jerry&#39;s &quot;show&quot; &lt;b&gt;',
+    )
+  })
+})

--- a/src/lib/email/utils.ts
+++ b/src/lib/email/utils.ts
@@ -1,0 +1,11 @@
+// メール関連の共通ユーティリティ
+
+// HTMLエスケープ（XSS対策）
+// 文字列以外を渡したい場合は呼び出し側で String(value) するルール
+export const escapeHtml = (input: string): string =>
+  input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')

--- a/src/lib/validators/order.ts
+++ b/src/lib/validators/order.ts
@@ -1,0 +1,17 @@
+// 注文関連のバリデーションスキーマ
+import { z } from 'zod'
+
+// 配送先住所スキーマ
+// DBに保存されている shippingAddress (Json) を安全にパースする用途
+// 構造は src/constants/checkout.ts の ShippingAddress と一致させる
+export const shippingAddressSchema = z.object({
+  name: z.string(),
+  postalCode: z.string(),
+  prefecture: z.string(),
+  city: z.string(),
+  addressLine1: z.string(),
+  addressLine2: z.string().optional(),
+  phone: z.string(),
+})
+
+export type ShippingAddressParsed = z.infer<typeof shippingAddressSchema>


### PR DESCRIPTION
## 概要
Issue #32 の実装。Resend を使った注文確認メールと発送通知メールの送信機能を追加。

## 変更内容
- `src/lib/email/` に Resend クライアントと送信関数を追加
- HTMLテンプレート（注文確認・発送通知）を追加
- `src/constants/email.ts` に送信元・件名定数を追加
- 注文作成API（`/api/orders` POST）で成功時に確認メール送信
- 管理ステータス変更API（`/api/admin/orders/[id]/status` PUT）で `shipped` 遷移時に発送通知送信
- 送信失敗してもAPI本体のレスポンスは正常返却（メール失敗で注文処理を妨げない）

## 関連 Issue
Closes #32
