### PR TITLE
feat(admin): ユーザー管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   name         String?
   passwordHash String?
   role         Role     @default(USER)
+  isActive     Boolean  @default(true) // 追加: 有効/無効フラグ
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/src/app/(admin)/admin/users/[id]/page.tsx
+++ b/src/app/(admin)/admin/users/[id]/page.tsx
@@ -1,0 +1,93 @@
+// 管理画面 ユーザー詳細ページ（Server Component）
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { findUserById } from '@/lib/db/users'
+import { USER_ROLE_LABEL, type UserRole } from '@/constants/admin'
+
+export const metadata = {
+  title: 'ユーザー詳細 | 管理画面',
+}
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function AdminUserDetailPage({ params }: Props) {
+  const { id } = await params
+  const user = await findUserById(id)
+
+  if (!user) {
+    notFound()
+  }
+
+  const roleLabel = USER_ROLE_LABEL[user.role as UserRole] ?? user.role
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">ユーザー詳細</h1>
+          <p className="text-sm text-muted-foreground">登録ユーザーの情報を確認できます。</p>
+        </div>
+        <Link
+          href="/admin/users"
+          className="text-sm text-primary hover:underline"
+        >
+          ← 一覧に戻る
+        </Link>
+      </div>
+
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">ID</dt>
+            <dd className="mt-1 break-all text-sm font-mono">{user.id}</dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">名前</dt>
+            <dd className="mt-1 text-sm">{user.name ?? '(名前未設定)'}</dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">メール</dt>
+            <dd className="mt-1 break-all text-sm">{user.email}</dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">ロール</dt>
+            <dd className="mt-1 text-sm">{roleLabel}</dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">状態</dt>
+            <dd className="mt-1">
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  user.isActive
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                {user.isActive ? '有効' : '無効'}
+              </span>
+            </dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">注文件数</dt>
+            <dd className="mt-1 text-sm">{user._count.orders} 件</dd>
+          </div>
+          <div className="sm:col-span-1">
+            <dt className="text-xs font-medium text-muted-foreground">登録日</dt>
+            <dd className="mt-1 text-sm">
+              {new Date(user.createdAt).toLocaleString('ja-JP', {
+                timeZone: 'Asia/Tokyo',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,39 @@
+// 管理画面 ユーザー一覧ページ（Server Component）
+import { redirect } from 'next/navigation'
+import { UserTable } from '@/components/features/admin/UserTable'
+import { findAllUsers } from '@/lib/db/users'
+import { auth } from '@/lib/auth'
+import type { UserRole } from '@/constants/admin'
+
+export const metadata = {
+  title: 'ユーザー管理 | 管理画面',
+}
+
+export default async function AdminUsersPage() {
+  const session = await auth()
+  // レイアウトでもチェック済みだが、ID取得のため再取得
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  const users = await findAllUsers()
+
+  // role を UserRole 型へ絞り込む
+  const typedUsers = users.map((u) => ({
+    ...u,
+    role: u.role as UserRole,
+  }))
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">ユーザー管理</h1>
+        <p className="text-sm text-muted-foreground">
+          登録ユーザーのロール変更と有効/無効の切り替えができます。
+        </p>
+      </div>
+
+      <UserTable users={typedUsers} currentUserId={session.user.id} />
+    </div>
+  )
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,103 @@
+// 管理画面 ユーザー詳細・更新 API
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAdmin } from '@/lib/admin-auth'
+import {
+  findUserById,
+  updateUserRole,
+  updateUserActiveStatus,
+} from '@/lib/db/users'
+import { USER_ROLES } from '@/constants/admin'
+
+type RouteParams = { params: Promise<{ id: string }> }
+
+// PATCHボディのバリデーションスキーマ
+const updateUserSchema = z
+  .object({
+    role: z.enum(USER_ROLES).optional(),
+    isActive: z.boolean().optional(),
+  })
+  .refine((v) => v.role !== undefined || v.isActive !== undefined, {
+    message: '更新項目を指定してください',
+  })
+
+// GET /api/admin/users/[id] - ユーザー詳細
+export const GET = async (_req: NextRequest, { params }: RouteParams) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { id } = await params
+
+  try {
+    const user = await findUserById(id)
+    if (!user) {
+      return NextResponse.json(
+        { error: 'ユーザーが見つかりません', code: 'NOT_FOUND' },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ user })
+  } catch (err) {
+    console.error('[admin/users/[id] GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'ユーザー詳細の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+// PATCH /api/admin/users/[id] - ロール変更・有効化切り替え
+export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { id } = await params
+
+  // 自分自身のロール降格・無効化を禁止
+  if (check.session.user.id === id) {
+    return NextResponse.json(
+      { error: '自分自身のロールや有効状態は変更できません', code: 'SELF_MODIFICATION_FORBIDDEN' },
+      { status: 400 },
+    )
+  }
+
+  const body: unknown = await req.json().catch(() => null)
+  const parsed = updateUserSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'バリデーションエラー', code: 'VALIDATION_ERROR' },
+      { status: 400 },
+    )
+  }
+
+  const existing = await findUserById(id)
+  if (!existing) {
+    return NextResponse.json(
+      { error: 'ユーザーが見つかりません', code: 'NOT_FOUND' },
+      { status: 404 },
+    )
+  }
+
+  const { role, isActive } = parsed.data
+
+  try {
+    if (role !== undefined) {
+      await updateUserRole(id, role)
+    }
+    if (isActive !== undefined) {
+      await updateUserActiveStatus(id, isActive)
+    }
+    const user = await findUserById(id)
+    return NextResponse.json({ user })
+  } catch (err) {
+    console.error('[admin/users/[id] PATCH] エラー:', err)
+    return NextResponse.json(
+      { error: 'ユーザーの更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,23 @@
+// 管理画面 ユーザー一覧 API
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import { findAllUsers } from '@/lib/db/users'
+
+// GET /api/admin/users - ユーザー一覧取得
+export const GET = async () => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  try {
+    const users = await findAllUsers()
+    return NextResponse.json({ users })
+  } catch (err) {
+    console.error('[admin/users GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'ユーザー一覧の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/admin/UserTable.tsx
+++ b/src/components/features/admin/UserTable.tsx
@@ -1,0 +1,162 @@
+'use client'
+// 管理画面 ユーザー一覧テーブル（ロール変更・有効化切替）
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { USER_ROLES, USER_ROLE_LABEL, type UserRole } from '@/constants/admin'
+
+// 一覧表示で使うユーザーの型
+type AdminUser = {
+  id: string
+  name: string | null
+  email: string
+  role: UserRole
+  isActive: boolean
+  createdAt: Date
+}
+
+type Props = {
+  users: AdminUser[]
+  currentUserId: string
+}
+
+export const UserTable = ({ users, currentUserId }: Props) => {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  // PATCHリクエスト共通処理
+  const patchUser = async (id: string, body: { role?: UserRole; isActive?: boolean }) => {
+    setPendingId(id)
+    try {
+      const res = await fetch(`/api/admin/users/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const data: unknown = await res.json().catch(() => null)
+        const msg =
+          data !== null && typeof data === 'object' && 'error' in data
+            ? String((data as { error: unknown }).error)
+            : '更新に失敗しました'
+        window.alert(msg)
+        return
+      }
+      startTransition(() => router.refresh())
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  const handleRoleChange = (id: string, role: UserRole) => {
+    void patchUser(id, { role })
+  }
+
+  const handleToggleActive = (id: string, currentActive: boolean) => {
+    const label = currentActive ? '無効化' : '有効化'
+    if (!confirm(`このユーザーを${label}しますか？`)) return
+    void patchUser(id, { isActive: !currentActive })
+  }
+
+  if (users.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground">
+        ユーザーがまだ登録されていません。
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border bg-card shadow-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">名前</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">メール</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">ロール</th>
+              <th className="px-4 py-3 text-center font-medium text-muted-foreground">状態</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">登録日</th>
+              <th className="px-4 py-3 text-center font-medium text-muted-foreground">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => {
+              const isSelf = user.id === currentUserId
+              const isRowPending = pendingId === user.id || isPending
+              return (
+                <tr
+                  key={user.id}
+                  className="border-b last:border-0 transition-colors hover:bg-muted/30"
+                >
+                  <td className="px-4 py-3 font-medium">
+                    <Link
+                      href={`/admin/users/${user.id}`}
+                      className="hover:underline"
+                    >
+                      {user.name ?? '(名前未設定)'}
+                    </Link>
+                    {isSelf && (
+                      <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
+                        自分
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
+                  <td className="px-4 py-3">
+                    <select
+                      value={user.role}
+                      onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
+                      disabled={isSelf || isRowPending}
+                      aria-label={`${user.email} のロールを変更`}
+                      className="rounded-md border bg-background px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {USER_ROLES.map((r) => (
+                        <option key={r} value={r}>
+                          {USER_ROLE_LABEL[r]}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                        user.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'
+                      }`}
+                    >
+                      {user.isActive ? '有効' : '無効'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {new Date(user.createdAt).toLocaleDateString('ja-JP', {
+                      timeZone: 'Asia/Tokyo',
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                    })}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <button
+                      type="button"
+                      onClick={() => handleToggleActive(user.id, user.isActive)}
+                      disabled={isSelf || isRowPending}
+                      aria-label={`${user.email} を${user.isActive ? '無効化' : '有効化'}`}
+                      className={`inline-flex items-center gap-1 rounded-md border px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                        user.isActive
+                          ? 'border-orange-300 text-orange-600 hover:bg-orange-50'
+                          : 'border-green-300 text-green-600 hover:bg-green-50'
+                      }`}
+                    >
+                      {user.isActive ? '無効化' : '有効化'}
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layouts/AdminHeader.tsx
+++ b/src/components/layouts/AdminHeader.tsx
@@ -56,6 +56,13 @@ export const AdminHeader = () => {
           >
             クーポン管理
           </Link>
+          {/* 追加: ユーザー管理 */}
+          <Link
+            href="/admin/users"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ユーザー管理
+          </Link>
         </nav>
       </div>
     </header>

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -32,3 +32,14 @@ export const ADMIN_COUPON_PAGE_SIZE = 50
 
 // クーポンコードの最大文字数 // 追加
 export const COUPON_CODE_MAX_LENGTH = 32
+
+// 追加: ユーザーロール一覧
+export const USER_ROLES = ['USER', 'ADMIN'] as const
+export type UserRole = (typeof USER_ROLES)[number]
+
+// 追加: ユーザーロールの表示ラベル
+export const USER_ROLE_LABEL: Record<UserRole, string> = {
+  USER: '一般',
+  ADMIN: '管理者',
+}
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,6 +51,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const user = await findUserByEmail(credentials.email)
         if (!user?.passwordHash) return null
 
+        // 追加: 無効化されたユーザーはログイン不可
+        if (user.isActive === false) return null
+
         // パスワード照合（bcryptjs）
         const isValid = await bcrypt.compare(credentials.password, user.passwordHash)
         if (!isValid) return null

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/db/prisma'
-import type { Prisma } from '@/generated/prisma/client'
+import type { Prisma, Role } from '@/generated/prisma/client'
 
 // メールアドレスでユーザーを取得
 export const findUserByEmail = async (email: string) => {
@@ -15,8 +15,10 @@ export const findUserById = async (id: string) => {
       email: true,
       name: true,
       role: true,
+      isActive: true, // 追加
       createdAt: true,
       updatedAt: true,
+      _count: { select: { orders: true } }, // 追加: 管理画面で注文件数を表示
     },
   })
 }
@@ -39,5 +41,55 @@ export const findUsers = async (params: { take?: number; skip?: number }) => {
     take,
     skip,
     orderBy: { createdAt: 'desc' },
+  })
+}
+
+// 追加: 管理画面用 全ユーザー一覧（isActive を含む）
+export const findAllUsers = async (take?: number) => {
+  return prisma.user.findMany({
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      isActive: true,
+      createdAt: true,
+    },
+    ...(take !== undefined ? { take } : {}),
+    orderBy: { createdAt: 'desc' },
+  })
+}
+
+// 追加: ユーザーのロールを更新
+export const updateUserRole = async (id: string, role: Role) => {
+  return prisma.user.update({
+    where: { id },
+    data: { role },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+}
+
+// 追加: ユーザーの有効/無効ステータスを更新
+export const updateUserActiveStatus = async (id: string, isActive: boolean) => {
+  return prisma.user.update({
+    where: { id },
+    data: { isActive },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
   })
 }


### PR DESCRIPTION
## 概要\nIssue #42 の実装。`/admin/users` でユーザー一覧・ロール変更・有効化/無効化を提供。\n\n## 変更内容\n- Prisma `User.isActive` 追加\n- API: `/api/admin/users`、`/api/admin/users/[id]`（GET/PATCH、自分自身の変更は 400）\n- 画面: `/admin/users`、`UserTable`\n- AdminHeader にナビ追加\n\nCloses #42