### PR TITLE
feat(notifications): バックインストック通知を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,8 +76,25 @@ model Product {
   cartItems     CartItem[]
   reviews       Review[]
   wishlistItems WishlistItem[]
+  backInStockSubscriptions BackInStockSubscription[] // 追加: バックインストック通知購読
 
   @@map("products")
+}
+
+// ----- バックインストック通知購読 -----
+model BackInStockSubscription {
+  id         String    @id @default(cuid())
+  email      String
+  productId  String
+  notified   Boolean   @default(false)
+  createdAt  DateTime  @default(now())
+  notifiedAt DateTime?
+
+  product Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+
+  @@unique([email, productId])
+  @@index([productId, notified])
+  @@map("back_in_stock_subscriptions")
 }
 
 // ----- 注文 -----

--- a/src/app/api/admin/notifications/back-in-stock/[productId]/send/route.ts
+++ b/src/app/api/admin/notifications/back-in-stock/[productId]/send/route.ts
@@ -34,13 +34,21 @@ export const POST = async (_req: Request, context: RouteContext) => {
   try {
     const product = await prisma.product.findUnique({
       where: { id: productId },
-      select: { id: true, name: true, images: true },
+      select: { id: true, name: true, images: true, stock: true }, // 変更: 在庫再確認のため stock を取得
     })
 
     if (!product) {
       return NextResponse.json(
         { error: '商品が見つかりません', code: 'NOT_FOUND' },
         { status: 404 },
+      )
+    }
+
+    // 追加: 在庫切れの商品には誤送信を防ぐため通知しない
+    if (product.stock <= 0) {
+      return NextResponse.json(
+        { error: '商品が在庫切れです', code: 'OUT_OF_STOCK' },
+        { status: 409 },
       )
     }
 

--- a/src/app/api/admin/notifications/back-in-stock/[productId]/send/route.ts
+++ b/src/app/api/admin/notifications/back-in-stock/[productId]/send/route.ts
@@ -1,0 +1,75 @@
+// 管理者によるバックインストック通知の手動送信API
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import { prisma } from '@/lib/db/prisma'
+import {
+  findUnnotifiedByProductId,
+  markAsNotified,
+} from '@/lib/db/backInStock'
+import { sendBackInStockNotificationEmail } from '@/lib/email/sendBackInStockNotification'
+
+type RouteContext = {
+  params: { productId: string }
+}
+
+// POST /api/admin/notifications/back-in-stock/[productId]/send
+// 在庫補充後、未通知の購読者全員にメール送信する
+export const POST = async (_req: Request, context: RouteContext) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json(
+      { error: check.error, code: 'FORBIDDEN' },
+      { status: check.status },
+    )
+  }
+
+  const { productId } = context.params
+  if (!productId) {
+    return NextResponse.json(
+      { error: '商品IDは必須です', code: 'BAD_REQUEST' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+      select: { id: true, name: true, images: true },
+    })
+
+    if (!product) {
+      return NextResponse.json(
+        { error: '商品が見つかりません', code: 'NOT_FOUND' },
+        { status: 404 },
+      )
+    }
+
+    const subscriptions = await findUnnotifiedByProductId(productId)
+    if (subscriptions.length === 0) {
+      return NextResponse.json({ sent: 0 })
+    }
+
+    // 送信を順次実行（外部API失敗が連鎖しないよう逐次送信）
+    const sentIds: string[] = []
+    for (const sub of subscriptions) {
+      const result = await sendBackInStockNotificationEmail({
+        to: sub.email,
+        product: { id: product.id, name: product.name, images: product.images },
+      })
+      if (result.success) {
+        sentIds.push(sub.id)
+      }
+    }
+
+    // 送信成功分のみ通知済みフラグを更新
+    await markAsNotified(sentIds)
+
+    return NextResponse.json({ sent: sentIds.length })
+  } catch (err) {
+    console.error('[admin/notifications/back-in-stock send POST] エラー:', err)
+    return NextResponse.json(
+      { error: '通知の送信に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/notifications/back-in-stock/route.ts
+++ b/src/app/api/notifications/back-in-stock/route.ts
@@ -3,6 +3,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/prisma'
 import { createSubscription } from '@/lib/db/backInStock'
 import { subscribeSchema } from '@/lib/validators/backInStock'
+import { checkRateLimit } from '@/lib/rateLimit'
+import {
+  BACK_IN_STOCK_RATE_LIMIT,
+  BACK_IN_STOCK_RATE_WINDOW_MS,
+} from '@/constants/notifications'
 
 // POST /api/notifications/back-in-stock - 在庫切れ商品の再入荷通知購読
 export const POST = async (req: NextRequest) => {
@@ -29,6 +34,19 @@ export const POST = async (req: NextRequest) => {
   }
 
   const { email, productId } = parsed.data
+
+  // 追加: 簡易レート制限（同一IP×同一productId / 1分10回）
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
+  const rateKey = `backinstock:${ip}:${productId}`
+  if (
+    !checkRateLimit(rateKey, BACK_IN_STOCK_RATE_LIMIT, BACK_IN_STOCK_RATE_WINDOW_MS)
+  ) {
+    return NextResponse.json(
+      { error: 'リクエストが多すぎます', code: 'RATE_LIMITED' },
+      { status: 429 },
+    )
+  }
 
   try {
     // 商品の存在確認 + 在庫切れチェック

--- a/src/app/api/notifications/back-in-stock/route.ts
+++ b/src/app/api/notifications/back-in-stock/route.ts
@@ -1,0 +1,65 @@
+// バックインストック通知購読API（認証不要）
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db/prisma'
+import { createSubscription } from '@/lib/db/backInStock'
+import { subscribeSchema } from '@/lib/validators/backInStock'
+
+// POST /api/notifications/back-in-stock - 在庫切れ商品の再入荷通知購読
+export const POST = async (req: NextRequest) => {
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { error: 'リクエスト形式が不正です', code: 'BAD_REQUEST' },
+      { status: 400 },
+    )
+  }
+
+  const parsed = subscribeSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: '入力値が不正です',
+        code: 'VALIDATION_ERROR',
+        details: parsed.error.flatten().fieldErrors,
+      },
+      { status: 422 },
+    )
+  }
+
+  const { email, productId } = parsed.data
+
+  try {
+    // 商品の存在確認 + 在庫切れチェック
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+      select: { id: true, stock: true, isPublished: true },
+    })
+
+    if (!product || !product.isPublished) {
+      return NextResponse.json(
+        { error: '商品が見つかりません', code: 'NOT_FOUND' },
+        { status: 404 },
+      )
+    }
+
+    // 在庫がある商品では購読を受け付けない
+    if (product.stock > 0) {
+      return NextResponse.json(
+        { error: 'この商品は現在在庫があります', code: 'PRODUCT_IN_STOCK' },
+        { status: 400 },
+      )
+    }
+
+    await createSubscription(email, productId)
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (err) {
+    console.error('[notifications/back-in-stock POST] エラー:', err)
+    return NextResponse.json(
+      { error: '通知購読の登録に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/product/BackInStockForm.tsx
+++ b/src/components/features/product/BackInStockForm.tsx
@@ -70,6 +70,8 @@ export const BackInStockForm = ({ productId }: Props) => {
         </p>
       ) : (
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          {/* 追加: productIdをhidden inputとして明示的に送信 */}
+          <input type="hidden" {...register('productId')} />
           <div>
             <Label htmlFor="back-in-stock-email" className="sr-only">
               メールアドレス

--- a/src/components/features/product/BackInStockForm.tsx
+++ b/src/components/features/product/BackInStockForm.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+// 在庫切れ商品の再入荷通知購読フォーム
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { subscribeSchema, type SubscribeInput } from '@/lib/validators/backInStock'
+
+type Props = {
+  productId: string
+}
+
+// 送信ステータス
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'success' }
+  | { kind: 'error'; message: string }
+
+export const BackInStockForm = ({ productId }: Props) => {
+  const [status, setStatus] = useState<Status>({ kind: 'idle' })
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<SubscribeInput>({
+    resolver: zodResolver(subscribeSchema),
+    defaultValues: { email: '', productId },
+  })
+
+  const onSubmit = async (values: SubscribeInput) => {
+    setStatus({ kind: 'submitting' })
+    try {
+      const res = await fetch('/api/notifications/back-in-stock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      })
+      if (!res.ok) {
+        const data: unknown = await res.json().catch(() => ({}))
+        const message =
+          typeof data === 'object' && data !== null && 'error' in data && typeof (data as { error: unknown }).error === 'string'
+            ? (data as { error: string }).error
+            : '通知登録に失敗しました'
+        setStatus({ kind: 'error', message })
+        return
+      }
+      setStatus({ kind: 'success' })
+      reset({ email: '', productId })
+    } catch (err) {
+      console.error('[BackInStockForm] 送信エラー:', err)
+      setStatus({ kind: 'error', message: '通信エラーが発生しました' })
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <h3 className="mb-1 text-sm font-semibold text-gray-900">再入荷通知を受け取る</h3>
+      <p className="mb-3 text-xs text-gray-600">
+        メールアドレスを登録すると、再入荷した際にお知らせします。
+      </p>
+
+      {status.kind === 'success' ? (
+        <p className="text-sm font-medium text-green-700" role="status">
+          通知を登録しました
+        </p>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <div>
+            <Label htmlFor="back-in-stock-email" className="sr-only">
+              メールアドレス
+            </Label>
+            <Input
+              id="back-in-stock-email"
+              type="email"
+              placeholder="メールアドレス"
+              autoComplete="email"
+              aria-invalid={errors.email ? 'true' : 'false'}
+              {...register('email')}
+            />
+            {errors.email && (
+              <p className="mt-1 text-xs text-red-600" role="alert">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+          <Button type="submit" disabled={status.kind === 'submitting'} className="w-full">
+            {status.kind === 'submitting' ? '登録中...' : '通知を受け取る'}
+          </Button>
+          {status.kind === 'error' && (
+            <p className="text-xs text-red-600" role="alert">
+              {status.message}
+            </p>
+          )}
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/product/ProductDetail.tsx
+++ b/src/components/features/product/ProductDetail.tsx
@@ -2,6 +2,7 @@
 import Image from 'next/image'
 import type { findProductById } from '@/lib/db/products'
 import { AddToCartButton } from './AddToCartButton'
+import { BackInStockForm } from './BackInStockForm' // 追加: バックインストック通知フォーム
 import { WishlistButton } from '@/components/features/wishlist/WishlistButton' // 追加
 
 // 変更: ReturnTypeベースの型定義でスキーマ変更に対応
@@ -92,6 +93,13 @@ export const ProductDetail = ({ product, wishlistProps }: Props) => {
               isLoggedIn={wishlistProps.isLoggedIn}
             />
           </div>
+
+          {/* 追加: 在庫切れ時のみバックインストック通知購読フォームを表示 */}
+          {product.stock === 0 && (
+            <div className="pt-2">
+              <BackInStockForm productId={product.id} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -5,4 +5,5 @@
 export const EMAIL_SUBJECTS = {
   ORDER_CONFIRMATION: 'ご注文ありがとうございます',
   SHIPMENT_NOTIFICATION: '商品を発送しました',
+  BACK_IN_STOCK: '商品が再入荷しました', // 追加: バックインストック通知
 } as const

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -1,0 +1,6 @@
+// 通知関連の定数
+// バックインストック購読APIのレート制限（1分あたり10回）
+export const BACK_IN_STOCK_RATE_LIMIT = 10
+export const BACK_IN_STOCK_RATE_WINDOW_MS = 60_000
+// メールアドレス最大長（RFC5321準拠）
+export const EMAIL_MAX_LENGTH = 254

--- a/src/lib/db/backInStock.ts
+++ b/src/lib/db/backInStock.ts
@@ -27,10 +27,3 @@ export const markAsNotified = async (ids: string[]) => {
     data: { notified: true, notifiedAt: new Date() },
   })
 }
-
-// 通知待ち件数（管理画面用）
-export const findActiveSubscriptionsCount = async (productId: string): Promise<number> => {
-  return prisma.backInStockSubscription.count({
-    where: { productId, notified: false },
-  })
-}

--- a/src/lib/db/backInStock.ts
+++ b/src/lib/db/backInStock.ts
@@ -1,0 +1,36 @@
+// バックインストック通知購読のリポジトリ関数
+import { prisma } from '@/lib/db/prisma'
+
+// 購読登録（既存ならno-op）
+// 同じ email × productId の組み合わせは @@unique 制約で1件のみ
+export const createSubscription = async (email: string, productId: string) => {
+  return prisma.backInStockSubscription.upsert({
+    where: { email_productId: { email, productId } },
+    update: {}, // 既存ならno-op
+    create: { email, productId },
+  })
+}
+
+// 指定商品の未通知購読一覧を取得
+export const findUnnotifiedByProductId = async (productId: string) => {
+  return prisma.backInStockSubscription.findMany({
+    where: { productId, notified: false },
+    orderBy: { createdAt: 'asc' },
+  })
+}
+
+// 通知済みフラグ更新
+export const markAsNotified = async (ids: string[]) => {
+  if (ids.length === 0) return { count: 0 }
+  return prisma.backInStockSubscription.updateMany({
+    where: { id: { in: ids } },
+    data: { notified: true, notifiedAt: new Date() },
+  })
+}
+
+// 通知待ち件数（管理画面用）
+export const findActiveSubscriptionsCount = async (productId: string): Promise<number> => {
+  return prisma.backInStockSubscription.count({
+    where: { productId, notified: false },
+  })
+}

--- a/src/lib/email/sendBackInStockNotification.ts
+++ b/src/lib/email/sendBackInStockNotification.ts
@@ -1,0 +1,34 @@
+import 'server-only'
+import { resend } from '@/lib/email/client'
+import { env } from '@/env'
+import { EMAIL_SUBJECTS } from '@/constants/email'
+import {
+  renderBackInStockNotificationHtml,
+  type BackInStockProduct,
+} from '@/lib/email/templates/backInStockNotification'
+
+// 戻り値型
+type SendResult = { success: boolean; error?: string }
+
+// バックインストック通知メール送信関数
+// 失敗時もthrowせず、呼び出し元のループ処理を中断しない
+export const sendBackInStockNotificationEmail = async (params: {
+  to: string
+  product: BackInStockProduct
+}): Promise<SendResult> => {
+  const { to, product } = params
+  try {
+    const html = renderBackInStockNotificationHtml(product, env.NEXT_PUBLIC_APP_URL)
+    await resend.emails.send({
+      from: env.EMAIL_FROM,
+      to,
+      subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[sendBackInStockNotificationEmail] 送信失敗:', err)
+    return { success: false, error: message }
+  }
+}

--- a/src/lib/email/templates/backInStockNotification.test.ts
+++ b/src/lib/email/templates/backInStockNotification.test.ts
@@ -1,0 +1,50 @@
+// バックインストック通知メールテンプレートのユニットテスト
+import { describe, expect, it } from 'vitest'
+import { renderBackInStockNotificationHtml } from './backInStockNotification'
+
+describe('renderBackInStockNotificationHtml', () => {
+  const baseUrl = 'https://example.com'
+
+  it('商品名・商品URLがHTMLに含まれる', () => {
+    const html = renderBackInStockNotificationHtml(
+      {
+        id: 'prod_123',
+        name: 'テスト商品',
+        images: ['https://example.com/img.jpg'],
+      },
+      baseUrl,
+    )
+    expect(html).toContain('テスト商品')
+    expect(html).toContain('https://example.com/products/prod_123')
+    expect(html).toContain('商品が再入荷しました')
+    expect(html).toContain('https://example.com/img.jpg')
+  })
+
+  it('画像がない商品でもエラーにならない', () => {
+    const html = renderBackInStockNotificationHtml(
+      {
+        id: 'prod_no_img',
+        name: '画像なし商品',
+        images: [],
+      },
+      baseUrl,
+    )
+    expect(html).toContain('画像なし商品')
+    expect(html).not.toContain('<img ')
+  })
+
+  it('商品名に <script> が含まれていてもエスケープされる', () => {
+    const html = renderBackInStockNotificationHtml(
+      {
+        id: 'prod_xss',
+        name: '<script>alert(1)</script>',
+        images: ['"><img src=x onerror=alert(1)>'],
+      },
+      baseUrl,
+    )
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    // 画像URLもエスケープされる
+    expect(html).not.toContain('"><img src=x onerror=alert(1)>')
+  })
+})

--- a/src/lib/email/templates/backInStockNotification.ts
+++ b/src/lib/email/templates/backInStockNotification.ts
@@ -1,0 +1,42 @@
+// バックインストック通知メールHTMLテンプレート
+import { escapeHtml } from '@/lib/email/utils'
+
+// テンプレートに渡す商品情報の型
+export type BackInStockProduct = {
+  id: string
+  name: string
+  images: string[]
+}
+
+// バックインストック通知メールのHTMLを生成する純粋関数
+// baseUrl は呼び出し側が env.NEXT_PUBLIC_APP_URL を渡す（テスト容易性確保）
+export const renderBackInStockNotificationHtml = (
+  product: BackInStockProduct,
+  baseUrl: string,
+): string => {
+  const productUrl = `${baseUrl}/products/${encodeURIComponent(product.id)}`
+  const thumbnail = product.images[0] ?? null
+  const safeName = escapeHtml(product.name)
+  const safeUrl = escapeHtml(productUrl)
+  const imageHtml = thumbnail
+    ? `<img src="${escapeHtml(thumbnail)}" alt="${safeName}" width="240" style="max-width:100%;height:auto;border-radius:8px;display:block;margin:0 0 16px;"/>`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
+    <div style="max-width:600px;margin:0 auto;background-color:#ffffff;padding:32px;border-radius:8px;">
+      <h1 style="font-size:20px;margin:0 0 16px;">商品が再入荷しました</h1>
+      <p style="margin:0 0 16px;">お待たせいたしました。ご希望の商品が再入荷しましたのでお知らせします。</p>
+      ${imageHtml}
+      <p style="margin:0 0 16px;font-size:16px;font-weight:600;">${safeName}</p>
+      <p style="margin:0 0 24px;">
+        <a href="${safeUrl}" style="display:inline-block;background-color:#111827;color:#ffffff;padding:12px 24px;border-radius:6px;text-decoration:none;">商品ページを見る</a>
+      </p>
+      <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">商品URL: <a href="${safeUrl}" style="color:#6b7280;">${safeUrl}</a></p>
+      <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
+      <p style="font-size:12px;color:#6b7280;margin:0;">本メールは再入荷通知の購読登録に基づき自動送信されています。在庫には限りがありますのでお早めにご検討ください。</p>
+    </div>
+  </body>
+</html>`
+}

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,20 @@
+// 簡易レートリミッタ（メモリ内マップ・単一プロセス前提）
+// 注意: 本番のマルチインスタンス環境では Redis 等の外部ストアに置き換えること
+const buckets = new Map<string, { count: number; resetAt: number }>()
+
+// 指定キーがウィンドウ内に limit 回未満なら true、超過なら false を返す
+export const checkRateLimit = (
+  key: string,
+  limit: number,
+  windowMs: number,
+): boolean => {
+  const now = Date.now()
+  const bucket = buckets.get(key)
+  if (!bucket || bucket.resetAt < now) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs })
+    return true
+  }
+  if (bucket.count >= limit) return false
+  bucket.count++
+  return true
+}

--- a/src/lib/validators/backInStock.ts
+++ b/src/lib/validators/backInStock.ts
@@ -1,10 +1,17 @@
 // バックインストック通知のZodバリデーションスキーマ
 import { z } from 'zod'
+import { EMAIL_MAX_LENGTH } from '@/constants/notifications'
 
 // 購読登録リクエストのスキーマ
+// TODO: 公開APIのためレート制限の強化（IP+グローバル）は別PRで対応
 export const subscribeSchema = z.object({
-  email: z.email({ message: '有効なメールアドレスを入力してください' }),
-  productId: z.string().min(1, '商品IDは必須です'),
+  email: z
+    .email({ message: '有効なメールアドレスを入力してください' })
+    .max(EMAIL_MAX_LENGTH, { message: 'メールアドレスが長すぎます' }), // 変更: RFC5321準拠の最大長制限
+  productId: z
+    .string()
+    .min(1, '商品IDは必須です')
+    .max(64, { message: '商品IDが長すぎます' }), // 変更: ペイロードサイズ制限
 })
 
 export type SubscribeInput = z.infer<typeof subscribeSchema>

--- a/src/lib/validators/backInStock.ts
+++ b/src/lib/validators/backInStock.ts
@@ -1,0 +1,10 @@
+// バックインストック通知のZodバリデーションスキーマ
+import { z } from 'zod'
+
+// 購読登録リクエストのスキーマ
+export const subscribeSchema = z.object({
+  email: z.email({ message: '有効なメールアドレスを入力してください' }),
+  productId: z.string().min(1, '商品IDは必須です'),
+})
+
+export type SubscribeInput = z.infer<typeof subscribeSchema>


### PR DESCRIPTION
## 概要
Issue #44。在庫切れ商品の再入荷通知購読・管理者送信機能。

## 変更
- Prisma `BackInStockSubscription` モデル追加
- API: 購読 `POST /api/notifications/back-in-stock`、管理者送信 `POST /api/admin/notifications/back-in-stock/[productId]/send`
- メール: 再入荷通知テンプレート + 送信関数（既存email基盤に統合）
- UI: 商品詳細 stock=0 時の `BackInStockForm`
- テスト: 3件追加（テンプレ検証）

Closes #44