### PR TITLE
feat(admin): メール通知テンプレート管理を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,25 @@ enum OrderStatus {
   CANCELLED
 }
 
+// 追加: メール通知テンプレート種別
+enum EmailTemplateKey {
+  ORDER_CONFIRMATION
+  SHIPMENT_NOTIFICATION
+  BACK_IN_STOCK
+}
+
+// 追加: メール通知テンプレートモデル
+model EmailTemplate {
+  id        String           @id @default(cuid())
+  key       EmailTemplateKey @unique
+  subject   String
+  bodyHtml  String
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@map("email_templates")
+}
+
 // ----- ユーザー -----
 model User {
   id           String   @id @default(cuid())

--- a/src/app/(admin)/admin/email-templates/[key]/page.tsx
+++ b/src/app/(admin)/admin/email-templates/[key]/page.tsx
@@ -5,11 +5,11 @@ import { ChevronLeft } from 'lucide-react'
 import { findEmailTemplateByKey } from '@/lib/db/emailTemplates'
 import { EmailTemplateForm } from '@/components/features/admin/EmailTemplateForm'
 import {
-  EMAIL_SUBJECTS,
   EMAIL_TEMPLATE_KEYS,
   EMAIL_TEMPLATE_LABELS,
   type EmailTemplateKeyValue,
 } from '@/constants/email'
+import { EMAIL_FALLBACK_TEMPLATES } from '@/lib/email/fallbacks' // 追加: 雛形を一元化
 
 export const metadata = {
   title: 'メールテンプレート編集 | 管理画面',
@@ -22,35 +22,6 @@ const VALID_KEYS = new Set<string>([
   EMAIL_TEMPLATE_KEYS.BACK_IN_STOCK,
 ])
 
-// フォールバックのデフォルト本文（DB未登録時の編集起点として提示する雛形）
-const FALLBACK_BODIES: Record<EmailTemplateKeyValue, { subject: string; bodyHtml: string }> = {
-  ORDER_CONFIRMATION: {
-    subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
-    bodyHtml: `<p>{{customerName}} 様</p>
-<p>この度はご注文いただきありがとうございます。以下の内容で承りました。</p>
-<p><strong>注文番号:</strong> {{orderNumber}}<br/>
-<strong>合計金額:</strong> {{totalAmount}}</p>
-<h2>ご注文内容</h2>
-{{itemsHtml}}
-<p>商品の発送までしばらくお待ちください。</p>`,
-  },
-  SHIPMENT_NOTIFICATION: {
-    subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
-    bodyHtml: `<p>{{customerName}} 様</p>
-<p>ご注文の商品を発送しました。</p>
-<p><strong>注文番号:</strong> {{orderNumber}}<br/>
-<strong>追跡番号:</strong> {{trackingNumber}}</p>
-<p>到着まで今しばらくお待ちください。</p>`,
-  },
-  BACK_IN_STOCK: {
-    subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
-    bodyHtml: `<p>お待たせしました。ご希望の商品が再入荷しました。</p>
-<p><strong>{{productName}}</strong></p>
-<p><a href="{{productUrl}}">商品ページを見る</a></p>
-<p>在庫には限りがありますのでお早めにご検討ください。</p>`,
-  },
-}
-
 type Props = {
   params: Promise<{ key: string }>
 }
@@ -61,7 +32,7 @@ export default async function AdminEmailTemplateEditPage({ params }: Props) {
   const typedKey = key as EmailTemplateKeyValue
 
   const stored = await findEmailTemplateByKey(typedKey)
-  const fallback = FALLBACK_BODIES[typedKey]
+  const fallback = EMAIL_FALLBACK_TEMPLATES[typedKey]
   const subject = stored?.subject ?? fallback.subject
   const bodyHtml = stored?.bodyHtml ?? fallback.bodyHtml
 

--- a/src/app/(admin)/admin/email-templates/[key]/page.tsx
+++ b/src/app/(admin)/admin/email-templates/[key]/page.tsx
@@ -1,0 +1,99 @@
+// 管理画面 メール通知テンプレート編集ページ（Server Component）
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+import { findEmailTemplateByKey } from '@/lib/db/emailTemplates'
+import { EmailTemplateForm } from '@/components/features/admin/EmailTemplateForm'
+import {
+  EMAIL_SUBJECTS,
+  EMAIL_TEMPLATE_KEYS,
+  EMAIL_TEMPLATE_LABELS,
+  type EmailTemplateKeyValue,
+} from '@/constants/email'
+
+export const metadata = {
+  title: 'メールテンプレート編集 | 管理画面',
+}
+
+// key 検証用セット
+const VALID_KEYS = new Set<string>([
+  EMAIL_TEMPLATE_KEYS.ORDER_CONFIRMATION,
+  EMAIL_TEMPLATE_KEYS.SHIPMENT_NOTIFICATION,
+  EMAIL_TEMPLATE_KEYS.BACK_IN_STOCK,
+])
+
+// フォールバックのデフォルト本文（DB未登録時の編集起点として提示する雛形）
+const FALLBACK_BODIES: Record<EmailTemplateKeyValue, { subject: string; bodyHtml: string }> = {
+  ORDER_CONFIRMATION: {
+    subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+    bodyHtml: `<p>{{customerName}} 様</p>
+<p>この度はご注文いただきありがとうございます。以下の内容で承りました。</p>
+<p><strong>注文番号:</strong> {{orderNumber}}<br/>
+<strong>合計金額:</strong> {{totalAmount}}</p>
+<h2>ご注文内容</h2>
+{{itemsHtml}}
+<p>商品の発送までしばらくお待ちください。</p>`,
+  },
+  SHIPMENT_NOTIFICATION: {
+    subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+    bodyHtml: `<p>{{customerName}} 様</p>
+<p>ご注文の商品を発送しました。</p>
+<p><strong>注文番号:</strong> {{orderNumber}}<br/>
+<strong>追跡番号:</strong> {{trackingNumber}}</p>
+<p>到着まで今しばらくお待ちください。</p>`,
+  },
+  BACK_IN_STOCK: {
+    subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
+    bodyHtml: `<p>お待たせしました。ご希望の商品が再入荷しました。</p>
+<p><strong>{{productName}}</strong></p>
+<p><a href="{{productUrl}}">商品ページを見る</a></p>
+<p>在庫には限りがありますのでお早めにご検討ください。</p>`,
+  },
+}
+
+type Props = {
+  params: Promise<{ key: string }>
+}
+
+export default async function AdminEmailTemplateEditPage({ params }: Props) {
+  const { key } = await params
+  if (!VALID_KEYS.has(key)) notFound()
+  const typedKey = key as EmailTemplateKeyValue
+
+  const stored = await findEmailTemplateByKey(typedKey)
+  const fallback = FALLBACK_BODIES[typedKey]
+  const subject = stored?.subject ?? fallback.subject
+  const bodyHtml = stored?.bodyHtml ?? fallback.bodyHtml
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="flex items-center gap-2">
+        <Link
+          href="/admin/email-templates"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft size={16} aria-hidden="true" />
+          一覧に戻る
+        </Link>
+      </div>
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {EMAIL_TEMPLATE_LABELS[typedKey]}の編集
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          件名と本文（HTML）を編集できます。プレースホルダー（例：
+          <code className="rounded bg-muted px-1">{'{{orderNumber}}'}</code>
+          ）は送信時に実値へ置換されます。
+        </p>
+      </div>
+
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <EmailTemplateForm
+          templateKey={typedKey}
+          defaultSubject={subject}
+          defaultBodyHtml={bodyHtml}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/email-templates/page.tsx
+++ b/src/app/(admin)/admin/email-templates/page.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link'
 import { Pencil } from 'lucide-react'
 import { findAllEmailTemplates } from '@/lib/db/emailTemplates'
 import {
-  EMAIL_SUBJECTS,
   EMAIL_TEMPLATE_KEYS,
   EMAIL_TEMPLATE_LABELS,
   type EmailTemplateKeyValue,
 } from '@/constants/email'
+import { EMAIL_FALLBACK_SUBJECTS } from '@/lib/email/fallbacks' // 追加: 雛形を一元化
 
 export const metadata = {
   title: 'メールテンプレート管理 | 管理画面',
@@ -19,13 +19,6 @@ const ALL_KEYS: readonly EmailTemplateKeyValue[] = [
   EMAIL_TEMPLATE_KEYS.SHIPMENT_NOTIFICATION,
   EMAIL_TEMPLATE_KEYS.BACK_IN_STOCK,
 ]
-
-// フォールバックの件名（DB未登録時に表示）
-const FALLBACK_SUBJECTS: Record<EmailTemplateKeyValue, string> = {
-  ORDER_CONFIRMATION: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
-  SHIPMENT_NOTIFICATION: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
-  BACK_IN_STOCK: EMAIL_SUBJECTS.BACK_IN_STOCK,
-}
 
 export default async function AdminEmailTemplatesPage() {
   const stored = await findAllEmailTemplates()
@@ -54,7 +47,7 @@ export default async function AdminEmailTemplatesPage() {
           <tbody className="divide-y">
             {ALL_KEYS.map((key) => {
               const stored = map.get(key)
-              const subject = stored?.subject ?? FALLBACK_SUBJECTS[key]
+              const subject = stored?.subject ?? EMAIL_FALLBACK_SUBJECTS[key]
               return (
                 <tr key={key}>
                   <td className="px-4 py-3 font-medium">{EMAIL_TEMPLATE_LABELS[key]}</td>

--- a/src/app/(admin)/admin/email-templates/page.tsx
+++ b/src/app/(admin)/admin/email-templates/page.tsx
@@ -1,0 +1,90 @@
+// 管理画面 メール通知テンプレート一覧ページ（Server Component）
+import Link from 'next/link'
+import { Pencil } from 'lucide-react'
+import { findAllEmailTemplates } from '@/lib/db/emailTemplates'
+import {
+  EMAIL_SUBJECTS,
+  EMAIL_TEMPLATE_KEYS,
+  EMAIL_TEMPLATE_LABELS,
+  type EmailTemplateKeyValue,
+} from '@/constants/email'
+
+export const metadata = {
+  title: 'メールテンプレート管理 | 管理画面',
+}
+
+// 表示する全テンプレートキー（DB未登録分も「未カスタマイズ」として一覧表示する）
+const ALL_KEYS: readonly EmailTemplateKeyValue[] = [
+  EMAIL_TEMPLATE_KEYS.ORDER_CONFIRMATION,
+  EMAIL_TEMPLATE_KEYS.SHIPMENT_NOTIFICATION,
+  EMAIL_TEMPLATE_KEYS.BACK_IN_STOCK,
+]
+
+// フォールバックの件名（DB未登録時に表示）
+const FALLBACK_SUBJECTS: Record<EmailTemplateKeyValue, string> = {
+  ORDER_CONFIRMATION: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+  SHIPMENT_NOTIFICATION: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+  BACK_IN_STOCK: EMAIL_SUBJECTS.BACK_IN_STOCK,
+}
+
+export default async function AdminEmailTemplatesPage() {
+  const stored = await findAllEmailTemplates()
+  // key -> 保存済みテンプレートのマップ
+  const map = new Map(stored.map((t) => [t.key, t]))
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">メールテンプレート管理</h1>
+        <p className="text-sm text-muted-foreground">
+          注文確認・発送通知・在庫再入荷など、自動送信メールの件名と本文を編集できます。
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium">テンプレート</th>
+              <th className="px-4 py-3 text-left font-medium">件名</th>
+              <th className="px-4 py-3 text-left font-medium">状態</th>
+              <th className="px-4 py-3 text-right font-medium">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {ALL_KEYS.map((key) => {
+              const stored = map.get(key)
+              const subject = stored?.subject ?? FALLBACK_SUBJECTS[key]
+              return (
+                <tr key={key}>
+                  <td className="px-4 py-3 font-medium">{EMAIL_TEMPLATE_LABELS[key]}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{subject}</td>
+                  <td className="px-4 py-3">
+                    {stored ? (
+                      <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+                        カスタム
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                        既定
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link
+                      href={`/admin/email-templates/${key}`}
+                      className="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent"
+                    >
+                      <Pencil size={14} aria-hidden="true" />
+                      編集
+                    </Link>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/email-templates/[key]/route.ts
+++ b/src/app/api/admin/email-templates/[key]/route.ts
@@ -1,0 +1,93 @@
+// 管理画面 メール通知テンプレート 取得・更新 API（key 単位）
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import {
+  findEmailTemplateByKey,
+  upsertEmailTemplate,
+} from '@/lib/db/emailTemplates'
+import {
+  emailTemplateKeySchema,
+  emailTemplateUpsertSchema,
+} from '@/lib/validators/emailTemplate'
+
+type RouteContext = {
+  params: Promise<{ key: string }>
+}
+
+// GET /api/admin/email-templates/[key] - 1件取得
+export const GET = async (_req: NextRequest, ctx: RouteContext) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json(
+      { error: check.error, code: 'FORBIDDEN' },
+      { status: check.status },
+    )
+  }
+
+  const { key } = await ctx.params
+  const parsedKey = emailTemplateKeySchema.safeParse(key)
+  if (!parsedKey.success) {
+    return NextResponse.json(
+      { error: '不正なテンプレートキーです', code: 'VALIDATION_ERROR' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const template = await findEmailTemplateByKey(parsedKey.data)
+    return NextResponse.json({ template })
+  } catch (err) {
+    console.error('[admin/email-templates/[key] GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'メールテンプレートの取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+// PUT /api/admin/email-templates/[key] - upsert
+export const PUT = async (req: NextRequest, ctx: RouteContext) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json(
+      { error: check.error, code: 'FORBIDDEN' },
+      { status: check.status },
+    )
+  }
+
+  const { key } = await ctx.params
+  const parsedKey = emailTemplateKeySchema.safeParse(key)
+  if (!parsedKey.success) {
+    return NextResponse.json(
+      { error: '不正なテンプレートキーです', code: 'VALIDATION_ERROR' },
+      { status: 400 },
+    )
+  }
+
+  const body: unknown = await req.json()
+  const parsed = emailTemplateUpsertSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: parsed.error.issues[0]?.message ?? 'バリデーションエラー',
+        code: 'VALIDATION_ERROR',
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const template = await upsertEmailTemplate({
+      key: parsedKey.data,
+      subject: parsed.data.subject,
+      bodyHtml: parsed.data.bodyHtml,
+    })
+    return NextResponse.json({ template })
+  } catch (err) {
+    console.error('[admin/email-templates/[key] PUT] エラー:', err)
+    return NextResponse.json(
+      { error: 'メールテンプレートの保存に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/email-templates/route.ts
+++ b/src/app/api/admin/email-templates/route.ts
@@ -1,0 +1,26 @@
+// 管理画面 メール通知テンプレート一覧 API
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import { findAllEmailTemplates } from '@/lib/db/emailTemplates'
+
+// GET /api/admin/email-templates - テンプレート一覧取得
+export const GET = async () => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json(
+      { error: check.error, code: 'FORBIDDEN' },
+      { status: check.status },
+    )
+  }
+
+  try {
+    const templates = await findAllEmailTemplates()
+    return NextResponse.json({ templates })
+  } catch (err) {
+    console.error('[admin/email-templates GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'メールテンプレートの取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/admin/EmailTemplateForm.tsx
+++ b/src/components/features/admin/EmailTemplateForm.tsx
@@ -1,0 +1,177 @@
+'use client'
+// 管理画面 メールテンプレート編集フォーム（プレビュー付き）
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  emailTemplateUpsertSchema,
+  type EmailTemplateUpsertValues,
+} from '@/lib/validators/emailTemplate'
+import {
+  EMAIL_TEMPLATE_LABELS,
+  EMAIL_TEMPLATE_VARIABLES,
+  type EmailTemplateKeyValue,
+} from '@/constants/email'
+
+type Props = {
+  templateKey: EmailTemplateKeyValue
+  defaultSubject: string
+  defaultBodyHtml: string
+}
+
+export const EmailTemplateForm = ({
+  templateKey,
+  defaultSubject,
+  defaultBodyHtml,
+}: Props) => {
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<Date | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<EmailTemplateUpsertValues>({
+    resolver: zodResolver(emailTemplateUpsertSchema),
+    defaultValues: {
+      subject: defaultSubject,
+      bodyHtml: defaultBodyHtml,
+    },
+  })
+
+  // プレビュー用に bodyHtml を購読
+  const previewSubject = watch('subject')
+  const previewBodyHtml = watch('bodyHtml')
+
+  const onSubmit = async (data: EmailTemplateUpsertValues) => {
+    setServerError(null)
+    const res = await fetch(`/api/admin/email-templates/${templateKey}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json: unknown = await res.json().catch(() => null)
+      const message =
+        json !== null &&
+        typeof json === 'object' &&
+        'error' in json &&
+        typeof (json as Record<string, unknown>).error === 'string'
+          ? (json as Record<string, string>).error
+          : '保存に失敗しました'
+      setServerError(message)
+      return
+    }
+    setSavedAt(new Date())
+    router.refresh()
+  }
+
+  const variables = EMAIL_TEMPLATE_VARIABLES[templateKey]
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      {/* 編集フォーム */}
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <div className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">利用可能な変数</p>
+          <p className="mt-1">
+            本文・件名に <code className="rounded bg-muted px-1">{'{{変数名}}'}</code> 形式で記述すると送信時に置換されます。
+          </p>
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {variables.map((v) => (
+              <li key={v}>
+                <code className="rounded bg-muted px-1.5 py-0.5">{`{{${v}}}`}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="subject" className="text-sm font-medium">
+            件名 <span className="text-destructive" aria-hidden="true">*</span>
+          </label>
+          <input
+            id="subject"
+            type="text"
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-describedby={errors.subject ? 'subject-error' : undefined}
+            {...register('subject')}
+          />
+          {errors.subject && (
+            <p id="subject-error" className="text-sm text-destructive">
+              {errors.subject.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="bodyHtml" className="text-sm font-medium">
+            本文（HTML） <span className="text-destructive" aria-hidden="true">*</span>
+          </label>
+          <textarea
+            id="bodyHtml"
+            rows={20}
+            className="flex w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-describedby={errors.bodyHtml ? 'bodyHtml-error' : undefined}
+            {...register('bodyHtml')}
+          />
+          {errors.bodyHtml && (
+            <p id="bodyHtml-error" className="text-sm text-destructive">
+              {errors.bodyHtml.message}
+            </p>
+          )}
+        </div>
+
+        {serverError && (
+          <p role="alert" className="text-sm text-destructive">
+            {serverError}
+          </p>
+        )}
+        {savedAt && (
+          <p role="status" className="text-sm text-emerald-700">
+            保存しました（{savedAt.toLocaleTimeString('ja-JP')}）
+          </p>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center rounded-md bg-primary px-6 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            {isSubmitting ? '保存中...' : '保存する'}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/admin/email-templates')}
+            className="inline-flex items-center rounded-md border border-input px-6 py-2 text-sm font-medium transition-colors hover:bg-accent"
+          >
+            一覧に戻る
+          </button>
+        </div>
+      </form>
+
+      {/* プレビュー */}
+      <aside aria-label="メールプレビュー" className="space-y-3">
+        <div className="text-sm font-medium">
+          プレビュー（{EMAIL_TEMPLATE_LABELS[templateKey]}）
+        </div>
+        <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs">
+          <span className="text-muted-foreground">件名:</span>{' '}
+          <span className="font-medium">{previewSubject}</span>
+        </div>
+        <div className="overflow-auto rounded-md border bg-white p-4 max-h-[640px]">
+          {/* 管理者のみアクセスする画面のため dangerouslySetInnerHTML を許容 */}
+          <div dangerouslySetInnerHTML={{ __html: previewBodyHtml }} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          ※ プレビューは入力中のHTMLをそのまま描画します。<code>{'{{変数名}}'}</code>{' '}
+          は実送信時に置換されるため、ここではそのまま表示されます。
+        </p>
+      </aside>
+    </div>
+  )
+}

--- a/src/components/layouts/AdminHeader.tsx
+++ b/src/components/layouts/AdminHeader.tsx
@@ -70,6 +70,13 @@ export const AdminHeader = () => {
           >
             レビュー管理
           </Link>
+          {/* 追加: メールテンプレート管理 */}
+          <Link
+            href="/admin/email-templates"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            メールテンプレート
+          </Link>
         </nav>
       </div>
     </header>

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -1,9 +1,33 @@
 // メール送信関連の定数
 // 変更: 送信元アドレスは src/env.ts の EMAIL_FROM を参照（ハードコード解消）
 
-// メール件名
+// メール件名（DBにテンプレートが無い場合のフォールバック）
 export const EMAIL_SUBJECTS = {
   ORDER_CONFIRMATION: 'ご注文ありがとうございます',
   SHIPMENT_NOTIFICATION: '商品を発送しました',
   BACK_IN_STOCK: '商品が再入荷しました', // 追加: バックインストック通知
 } as const
+
+// 追加: メール通知テンプレートのキー（Prisma enum と一致）
+export const EMAIL_TEMPLATE_KEYS = {
+  ORDER_CONFIRMATION: 'ORDER_CONFIRMATION',
+  SHIPMENT_NOTIFICATION: 'SHIPMENT_NOTIFICATION',
+  BACK_IN_STOCK: 'BACK_IN_STOCK',
+} as const
+
+export type EmailTemplateKeyValue =
+  (typeof EMAIL_TEMPLATE_KEYS)[keyof typeof EMAIL_TEMPLATE_KEYS]
+
+// 追加: 管理画面で表示する日本語ラベル
+export const EMAIL_TEMPLATE_LABELS: Record<EmailTemplateKeyValue, string> = {
+  ORDER_CONFIRMATION: '注文確認メール',
+  SHIPMENT_NOTIFICATION: '発送通知メール',
+  BACK_IN_STOCK: '在庫再入荷通知メール',
+}
+
+// 追加: 各テンプレートで使用可能な変数（管理画面のヒント表示用）
+export const EMAIL_TEMPLATE_VARIABLES: Record<EmailTemplateKeyValue, readonly string[]> = {
+  ORDER_CONFIRMATION: ['orderNumber', 'customerName', 'totalAmount', 'itemsHtml'],
+  SHIPMENT_NOTIFICATION: ['orderNumber', 'customerName', 'trackingNumber'],
+  BACK_IN_STOCK: ['productName', 'productUrl'],
+}

--- a/src/lib/db/emailTemplates.ts
+++ b/src/lib/db/emailTemplates.ts
@@ -1,0 +1,50 @@
+// メール通知テンプレートのリポジトリ関数
+import { prisma } from '@/lib/db/prisma'
+import { EmailTemplateKey } from '@/generated/prisma/enums'
+
+// 全テンプレート取得（管理画面一覧用）
+export const findAllEmailTemplates = async () => {
+  return prisma.emailTemplate.findMany({
+    orderBy: { key: 'asc' },
+  })
+}
+
+// キーで1件取得
+export const findEmailTemplateByKey = async (key: EmailTemplateKey) => {
+  return prisma.emailTemplate.findUnique({ where: { key } })
+}
+
+// upsert（key を一意キーとして登録 or 更新）
+export const upsertEmailTemplate = async (params: {
+  key: EmailTemplateKey
+  subject: string
+  bodyHtml: string
+}) => {
+  const { key, subject, bodyHtml } = params
+  return prisma.emailTemplate.upsert({
+    where: { key },
+    create: { key, subject, bodyHtml },
+    update: { subject, bodyHtml },
+  })
+}
+
+// DB未登録時はfallbackを返す（送信関数からの利用）
+export const getEmailTemplateOrFallback = async (
+  key: EmailTemplateKey,
+  fallback: { subject: string; bodyHtml: string },
+): Promise<{ subject: string; bodyHtml: string; isCustom: boolean }> => {
+  try {
+    const template = await findEmailTemplateByKey(key)
+    if (template) {
+      return {
+        subject: template.subject,
+        bodyHtml: template.bodyHtml,
+        isCustom: true,
+      }
+    }
+  } catch (err) {
+    // DB接続失敗等はフォールバックで継続させる（送信処理を止めない）
+    console.error('[getEmailTemplateOrFallback] テンプレート取得失敗:', err)
+  }
+  return { ...fallback, isCustom: false }
+}

--- a/src/lib/email/fallbacks.ts
+++ b/src/lib/email/fallbacks.ts
@@ -1,0 +1,42 @@
+// 追加: メールテンプレートの雛形（DB未登録時のフォールバック）
+// 管理画面（一覧・編集）と送信側で同一の雛形を参照できるよう集約する
+import { EMAIL_SUBJECTS, type EmailTemplateKeyValue } from '@/constants/email'
+
+// テンプレート雛形（件名 + 本文HTML）
+export const EMAIL_FALLBACK_TEMPLATES: Record<
+  EmailTemplateKeyValue,
+  { subject: string; bodyHtml: string }
+> = {
+  ORDER_CONFIRMATION: {
+    subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+    bodyHtml: `<p>{{customerName}} 様</p>
+<p>この度はご注文いただきありがとうございます。以下の内容で承りました。</p>
+<p><strong>注文番号:</strong> {{orderNumber}}<br/>
+<strong>合計金額:</strong> {{totalAmount}}</p>
+<h2>ご注文内容</h2>
+{{itemsHtml}}
+<p>商品の発送までしばらくお待ちください。</p>`,
+  },
+  SHIPMENT_NOTIFICATION: {
+    subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+    bodyHtml: `<p>{{customerName}} 様</p>
+<p>ご注文の商品を発送しました。</p>
+<p><strong>注文番号:</strong> {{orderNumber}}<br/>
+<strong>追跡番号:</strong> {{trackingNumber}}</p>
+<p>到着まで今しばらくお待ちください。</p>`,
+  },
+  BACK_IN_STOCK: {
+    subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
+    bodyHtml: `<p>お待たせしました。ご希望の商品が再入荷しました。</p>
+<p><strong>{{productName}}</strong></p>
+<p><a href="{{productUrl}}">商品ページを見る</a></p>
+<p>在庫には限りがありますのでお早めにご検討ください。</p>`,
+  },
+}
+
+// 件名のみが必要な箇所向けの便宜マップ
+export const EMAIL_FALLBACK_SUBJECTS: Record<EmailTemplateKeyValue, string> = {
+  ORDER_CONFIRMATION: EMAIL_FALLBACK_TEMPLATES.ORDER_CONFIRMATION.subject,
+  SHIPMENT_NOTIFICATION: EMAIL_FALLBACK_TEMPLATES.SHIPMENT_NOTIFICATION.subject,
+  BACK_IN_STOCK: EMAIL_FALLBACK_TEMPLATES.BACK_IN_STOCK.subject,
+}

--- a/src/lib/email/sendBackInStockNotification.ts
+++ b/src/lib/email/sendBackInStockNotification.ts
@@ -34,12 +34,17 @@ export const sendBackInStockNotificationEmail = async (params: {
     let html = tpl.bodyHtml
 
     if (tpl.isCustom) {
-      const vars = {
+      // 変更: 件名は生値、本文はエスケープ値を埋め込む
+      const rawVars = {
+        productName: product.name,
+        productUrl: productUrl,
+      }
+      const htmlVars = {
         productName: escapeHtml(product.name),
         productUrl: escapeHtml(productUrl),
       }
-      subject = applyTemplateVariables(tpl.subject, vars)
-      html = applyTemplateVariables(tpl.bodyHtml, vars)
+      subject = applyTemplateVariables(tpl.subject, rawVars)
+      html = applyTemplateVariables(tpl.bodyHtml, htmlVars)
     }
 
     await resend.emails.send({

--- a/src/lib/email/sendBackInStockNotification.ts
+++ b/src/lib/email/sendBackInStockNotification.ts
@@ -6,6 +6,10 @@ import {
   renderBackInStockNotificationHtml,
   type BackInStockProduct,
 } from '@/lib/email/templates/backInStockNotification'
+import { getEmailTemplateOrFallback } from '@/lib/db/emailTemplates' // 追加
+import { applyTemplateVariables } from '@/lib/email/templateEngine' // 追加
+import { escapeHtml } from '@/lib/email/utils' // 追加
+import { EmailTemplateKey } from '@/generated/prisma/enums' // 追加
 
 // 戻り値型
 type SendResult = { success: boolean; error?: string }
@@ -18,11 +22,30 @@ export const sendBackInStockNotificationEmail = async (params: {
 }): Promise<SendResult> => {
   const { to, product } = params
   try {
-    const html = renderBackInStockNotificationHtml(product, env.NEXT_PUBLIC_APP_URL)
+    // 追加: DBにカスタムテンプレートがあれば優先使用
+    const productUrl = `${env.NEXT_PUBLIC_APP_URL}/products/${encodeURIComponent(product.id)}`
+    const fallbackHtml = renderBackInStockNotificationHtml(product, env.NEXT_PUBLIC_APP_URL)
+    const tpl = await getEmailTemplateOrFallback(EmailTemplateKey.BACK_IN_STOCK, {
+      subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
+      bodyHtml: fallbackHtml,
+    })
+
+    let subject = tpl.subject
+    let html = tpl.bodyHtml
+
+    if (tpl.isCustom) {
+      const vars = {
+        productName: escapeHtml(product.name),
+        productUrl: escapeHtml(productUrl),
+      }
+      subject = applyTemplateVariables(tpl.subject, vars)
+      html = applyTemplateVariables(tpl.bodyHtml, vars)
+    }
+
     await resend.emails.send({
       from: env.EMAIL_FROM,
       to,
-      subject: EMAIL_SUBJECTS.BACK_IN_STOCK,
+      subject,
       html,
     })
     return { success: true }

--- a/src/lib/email/sendOrderConfirmation.ts
+++ b/src/lib/email/sendOrderConfirmation.ts
@@ -4,9 +4,15 @@ import { env } from '@/env' // 変更: 送信元アドレスを環境変数か�
 import { EMAIL_SUBJECTS } from '@/constants/email'
 import {
   renderOrderConfirmationHtml,
+  renderOrderConfirmationItemsHtml, // 追加
+  formatOrderJpy, // 追加
   type OrderConfirmationItem,
   type OrderConfirmationOrder,
 } from '@/lib/email/templates/orderConfirmation'
+import { getEmailTemplateOrFallback } from '@/lib/db/emailTemplates' // 追加
+import { applyTemplateVariables } from '@/lib/email/templateEngine' // 追加
+import { escapeHtml } from '@/lib/email/utils' // 追加
+import { EmailTemplateKey } from '@/generated/prisma/enums' // 追加
 
 // 戻り値型
 type SendResult = { success: boolean; error?: string }
@@ -20,11 +26,33 @@ export const sendOrderConfirmationEmail = async (params: {
 }): Promise<SendResult> => {
   const { to, order, items } = params
   try {
-    const html = renderOrderConfirmationHtml(order, items)
+    // 追加: DBにカスタムテンプレートがあれば優先使用、無ければ従来のレンダラー
+    const fallbackHtml = renderOrderConfirmationHtml(order, items)
+    const tpl = await getEmailTemplateOrFallback(EmailTemplateKey.ORDER_CONFIRMATION, {
+      subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+      bodyHtml: fallbackHtml,
+    })
+
+    let subject = tpl.subject
+    let html = tpl.bodyHtml
+
+    if (tpl.isCustom) {
+      // カスタムテンプレートに変数を埋め込む（顧客入力値はescapeHtmlで安全化）
+      const vars = {
+        orderNumber: escapeHtml(order.id),
+        customerName: escapeHtml(order.shippingAddress.name),
+        totalAmount: formatOrderJpy(order.totalPrice),
+        // itemsHtml は内部生成のためエスケープ済みtr群（HTML埋め込みを許容）
+        itemsHtml: renderOrderConfirmationItemsHtml(items),
+      }
+      subject = applyTemplateVariables(tpl.subject, vars)
+      html = applyTemplateVariables(tpl.bodyHtml, vars)
+    }
+
     await resend.emails.send({
       from: env.EMAIL_FROM, // 変更: ハードコード解消
       to,
-      subject: EMAIL_SUBJECTS.ORDER_CONFIRMATION,
+      subject,
       html,
     })
     return { success: true }

--- a/src/lib/email/sendOrderConfirmation.ts
+++ b/src/lib/email/sendOrderConfirmation.ts
@@ -37,16 +37,25 @@ export const sendOrderConfirmationEmail = async (params: {
     let html = tpl.bodyHtml
 
     if (tpl.isCustom) {
-      // カスタムテンプレートに変数を埋め込む（顧客入力値はescapeHtmlで安全化）
-      const vars = {
+      // 変更: 件名はプレーンテキストのため生値、本文はHTMLのためエスケープ値を埋め込む
+      const totalAmount = formatOrderJpy(order.totalPrice)
+      // 件名用（生値）
+      const rawVars = {
+        orderNumber: order.id,
+        customerName: order.shippingAddress.name,
+        totalAmount,
+        // 件名にitemsHtmlを埋め込むことは想定しないが、誤って含めても安全な空文字を渡す
+        itemsHtml: '',
+      }
+      // 本文用（顧客入力値はescapeHtmlで安全化、itemsHtmlは内部生成済みHTML）
+      const htmlVars = {
         orderNumber: escapeHtml(order.id),
         customerName: escapeHtml(order.shippingAddress.name),
-        totalAmount: formatOrderJpy(order.totalPrice),
-        // itemsHtml は内部生成のためエスケープ済みtr群（HTML埋め込みを許容）
+        totalAmount,
         itemsHtml: renderOrderConfirmationItemsHtml(items),
       }
-      subject = applyTemplateVariables(tpl.subject, vars)
-      html = applyTemplateVariables(tpl.bodyHtml, vars)
+      subject = applyTemplateVariables(tpl.subject, rawVars)
+      html = applyTemplateVariables(tpl.bodyHtml, htmlVars)
     }
 
     await resend.emails.send({

--- a/src/lib/email/sendShipmentNotification.ts
+++ b/src/lib/email/sendShipmentNotification.ts
@@ -6,23 +6,48 @@ import {
   renderShipmentNotificationHtml,
   type ShipmentNotificationOrder,
 } from '@/lib/email/templates/shipmentNotification'
+import { getEmailTemplateOrFallback } from '@/lib/db/emailTemplates' // 追加
+import { applyTemplateVariables } from '@/lib/email/templateEngine' // 追加
+import { escapeHtml } from '@/lib/email/utils' // 追加
+import { EmailTemplateKey } from '@/generated/prisma/enums' // 追加
 
 // 戻り値型
 type SendResult = { success: boolean; error?: string }
 
 // 発送通知メール送信関数
 // 失敗時もthrowせず、注文ステータス変更処理本体に影響を与えない
+// 追加: trackingNumber は任意（未指定時は空文字で置換）
 export const sendShipmentNotificationEmail = async (params: {
   to: string
   order: ShipmentNotificationOrder
+  trackingNumber?: string
 }): Promise<SendResult> => {
-  const { to, order } = params
+  const { to, order, trackingNumber } = params
   try {
-    const html = renderShipmentNotificationHtml(order)
+    // 追加: DBにカスタムテンプレートがあれば優先使用、無ければ従来のレンダラー
+    const fallbackHtml = renderShipmentNotificationHtml(order)
+    const tpl = await getEmailTemplateOrFallback(EmailTemplateKey.SHIPMENT_NOTIFICATION, {
+      subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+      bodyHtml: fallbackHtml,
+    })
+
+    let subject = tpl.subject
+    let html = tpl.bodyHtml
+
+    if (tpl.isCustom) {
+      const vars = {
+        orderNumber: escapeHtml(order.id),
+        customerName: escapeHtml(order.shippingAddress.name),
+        trackingNumber: trackingNumber ? escapeHtml(trackingNumber) : '',
+      }
+      subject = applyTemplateVariables(tpl.subject, vars)
+      html = applyTemplateVariables(tpl.bodyHtml, vars)
+    }
+
     await resend.emails.send({
       from: env.EMAIL_FROM, // 変更: ハードコード解消
       to,
-      subject: EMAIL_SUBJECTS.SHIPMENT_NOTIFICATION,
+      subject,
       html,
     })
     return { success: true }

--- a/src/lib/email/sendShipmentNotification.ts
+++ b/src/lib/email/sendShipmentNotification.ts
@@ -35,13 +35,19 @@ export const sendShipmentNotificationEmail = async (params: {
     let html = tpl.bodyHtml
 
     if (tpl.isCustom) {
-      const vars = {
+      // 変更: 件名は生値、本文はエスケープ値を埋め込む
+      const rawVars = {
+        orderNumber: order.id,
+        customerName: order.shippingAddress.name,
+        trackingNumber: trackingNumber ?? '',
+      }
+      const htmlVars = {
         orderNumber: escapeHtml(order.id),
         customerName: escapeHtml(order.shippingAddress.name),
         trackingNumber: trackingNumber ? escapeHtml(trackingNumber) : '',
       }
-      subject = applyTemplateVariables(tpl.subject, vars)
-      html = applyTemplateVariables(tpl.bodyHtml, vars)
+      subject = applyTemplateVariables(tpl.subject, rawVars)
+      html = applyTemplateVariables(tpl.bodyHtml, htmlVars)
     }
 
     await resend.emails.send({

--- a/src/lib/email/templateEngine.test.ts
+++ b/src/lib/email/templateEngine.test.ts
@@ -1,0 +1,60 @@
+// applyTemplateVariables のユニットテスト
+import { describe, expect, it } from 'vitest'
+import { applyTemplateVariables } from './templateEngine'
+
+describe('applyTemplateVariables', () => {
+  it('単一の変数を置換する', () => {
+    expect(applyTemplateVariables('Hello {{name}}', { name: '太郎' })).toBe('Hello 太郎')
+  })
+
+  it('複数の変数を置換する', () => {
+    const tpl = '注文番号: {{orderNumber}} / 顧客: {{customerName}} / 合計: {{totalAmount}}'
+    const result = applyTemplateVariables(tpl, {
+      orderNumber: 'ORD-001',
+      customerName: '山田',
+      totalAmount: 1980,
+    })
+    expect(result).toBe('注文番号: ORD-001 / 顧客: 山田 / 合計: 1980')
+  })
+
+  it('同じ変数が複数回出現してもすべて置換する', () => {
+    expect(applyTemplateVariables('{{x}} と {{x}}', { x: 'A' })).toBe('A と A')
+  })
+
+  it('未指定の変数はプレースホルダーのまま残す', () => {
+    expect(applyTemplateVariables('{{a}} {{b}}', { a: 'A' })).toBe('A {{b}}')
+  })
+
+  it('null や undefined の値はプレースホルダーのまま残す', () => {
+    expect(applyTemplateVariables('{{a}} {{b}}', { a: null, b: undefined })).toBe('{{a}} {{b}}')
+  })
+
+  it('変数が含まれていない文字列はそのまま返す', () => {
+    expect(applyTemplateVariables('変数なし', {})).toBe('変数なし')
+  })
+
+  it('プレースホルダー前後の空白を許容する', () => {
+    expect(applyTemplateVariables('{{ name }}', { name: '太郎' })).toBe('太郎')
+  })
+
+  it('数値を文字列に変換して置換する', () => {
+    expect(applyTemplateVariables('価格 {{price}}円', { price: 100 })).toBe('価格 100円')
+  })
+
+  it('値に含まれるHTMLはそのまま埋め込む（呼び出し側で事前エスケープする想定）', () => {
+    // テンプレートエンジン自体はエスケープしない（itemsHtml などHTML注入を許容するため）
+    // XSSを避けたい変数は呼び出し側で事前にescapeHtml()してから渡すルール
+    const result = applyTemplateVariables('<p>{{content}}</p>', {
+      content: '<script>alert(1)</script>',
+    })
+    expect(result).toBe('<p><script>alert(1)</script></p>')
+  })
+
+  it('値内の "$" などの正規表現特殊文字を破壊しない', () => {
+    expect(applyTemplateVariables('{{v}}', { v: '$1 & $2' })).toBe('$1 & $2')
+  })
+
+  it('プレースホルダー名と一致しないキーは無視する', () => {
+    expect(applyTemplateVariables('{{a}}', { other: 'X' })).toBe('{{a}}')
+  })
+})

--- a/src/lib/email/templateEngine.ts
+++ b/src/lib/email/templateEngine.ts
@@ -1,0 +1,24 @@
+// 簡易テンプレートエンジン: {{varName}} を変数値で置換する純粋関数
+// itemsHtml など一部の変数は HTML を含む可能性があるため、この関数自体はエスケープを行わない。
+// 呼び出し側で必要に応じて事前にエスケープした値を渡す（XSS対策の責務は呼び出し側）。
+
+// 置換対象のプレースホルダー正規表現: {{ varName }} 形式（前後空白許容）
+const PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g
+
+// 文字列中の {{key}} を vars[key] で置換する
+// vars に存在しないキーは元のまま残す（誤って空文字に置換しない）
+export const applyTemplateVariables = (
+  source: string,
+  vars: Record<string, string | number | undefined | null>,
+): string => {
+  return source.replace(PLACEHOLDER_PATTERN, (match, name: string) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, name)) {
+      return match
+    }
+    const value = vars[name]
+    if (value === undefined || value === null) {
+      return match
+    }
+    return String(value)
+  })
+}

--- a/src/lib/email/templates/orderConfirmation.ts
+++ b/src/lib/email/templates/orderConfirmation.ts
@@ -19,12 +19,11 @@ export type OrderConfirmationItem = {
 // 数値を日本円表記にフォーマット
 const formatJpy = (value: number): string => `¥${value.toLocaleString('ja-JP')}`
 
-// 注文確認メールのHTMLを生成する純粋関数
-export const renderOrderConfirmationHtml = (
-  order: OrderConfirmationOrder,
+// 追加: 注文明細をHTML（tr行）に変換する純粋関数（DBテンプレート利用時の {{itemsHtml}} にも使う）
+export const renderOrderConfirmationItemsHtml = (
   items: OrderConfirmationItem[],
 ): string => {
-  const itemsHtml = items
+  return items
     .map(
       (item) => `
         <tr>
@@ -35,6 +34,17 @@ export const renderOrderConfirmationHtml = (
         </tr>`,
     )
     .join('')
+}
+
+// 追加: 円フォーマットを外部に公開（送信関数からの利用）
+export const formatOrderJpy = formatJpy
+
+// 注文確認メールのHTMLを生成する純粋関数
+export const renderOrderConfirmationHtml = (
+  order: OrderConfirmationOrder,
+  items: OrderConfirmationItem[],
+): string => {
+  const itemsHtml = renderOrderConfirmationItemsHtml(items)
 
   const addr = order.shippingAddress
   const addressHtml = `

--- a/src/lib/validators/emailTemplate.ts
+++ b/src/lib/validators/emailTemplate.ts
@@ -1,0 +1,24 @@
+// メール通知テンプレートのバリデーションスキーマ
+import { z } from 'zod'
+import { EMAIL_TEMPLATE_KEYS } from '@/constants/email'
+
+// テンプレートキー
+export const emailTemplateKeySchema = z.enum([
+  EMAIL_TEMPLATE_KEYS.ORDER_CONFIRMATION,
+  EMAIL_TEMPLATE_KEYS.SHIPMENT_NOTIFICATION,
+  EMAIL_TEMPLATE_KEYS.BACK_IN_STOCK,
+])
+
+// テンプレート編集（subject / bodyHtml の更新）
+export const emailTemplateUpsertSchema = z.object({
+  subject: z
+    .string()
+    .min(1, '件名を入力してください')
+    .max(200, '件名は200文字以内で入力してください'),
+  bodyHtml: z
+    .string()
+    .min(1, '本文を入力してください')
+    .max(50000, '本文は50000文字以内で入力してください'),
+})
+
+export type EmailTemplateUpsertValues = z.infer<typeof emailTemplateUpsertSchema>


### PR DESCRIPTION
## 概要
Issue #45 の実装。管理画面でメール通知テンプレート（注文確認・発送通知・バックインストック）を編集できる機能を追加。

## 変更内容
- `EmailTemplate` モデル追加（key/subject/bodyHtml）
- `/admin/email-templates` 一覧・編集画面（プレビュー機能付き）
- API `/api/admin/email-templates`（GET/PUT）
- 既存メール送信関数を DBテンプレート優先・フォールバック対応
- `{{var}}` 置換エンジン + ユニットテスト 11ケース

Closes #45
