### PR TITLE
feat(seo): sitemap・robots・OG・構造化データを追加

### DIFF
--- a/src/app/(shop)/products/[id]/page.tsx
+++ b/src/app/(shop)/products/[id]/page.tsx
@@ -10,6 +10,8 @@ import { isProductInWishlist } from '@/lib/db/wishlist' // 追加
 import { ProductDetail } from '@/components/features/product/ProductDetail'
 import { ReviewForm } from '@/components/features/review/ReviewForm'
 import { ReviewList } from '@/components/features/review/ReviewList'
+import { env } from '@/env' // 追加: 構造化データ用URL生成
+import { SITE_NAME, TWITTER_CARD_TYPE } from '@/constants/seo' // 追加
 
 // 追加: React.cacheでラップして1リクエスト内のDBクエリ重複を解消
 const getCachedProductById = cache(findProductById)
@@ -24,13 +26,26 @@ export const generateMetadata = async ({ params }: Props): Promise<Metadata> => 
   if (!product) {
     return { title: '商品が見つかりません' }
   }
+  const description = product.description ?? `${product.name}の詳細ページです。`
+  const productUrl = `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products/${product.id}`
+  const images = product.images[0] ? [{ url: product.images[0] }] : undefined
+
   return {
     title: product.name,
-    description: product.description ?? `${product.name}の詳細ページです。`,
+    description,
     openGraph: {
+      type: 'website', // 変更: 仕様に合わせて 'website' を指定
       title: product.name,
-      description: product.description ?? `${product.name}の詳細ページです。`,
-      ...(product.images[0] ? { images: [{ url: product.images[0] }] } : {}),
+      description,
+      url: productUrl,
+      siteName: SITE_NAME,
+      ...(images ? { images } : {}),
+    },
+    twitter: {
+      card: TWITTER_CARD_TYPE,
+      title: product.name,
+      description,
+      ...(product.images[0] ? { images: [product.images[0]] } : {}),
     },
   }
 }
@@ -40,6 +55,25 @@ export default async function ProductDetailPage({ params }: Props) {
 
   if (!product) {
     notFound()
+  }
+
+  // 追加: 商品 構造化データ（JSON-LD）
+  const productJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: product.name,
+    image: product.images,
+    description: product.description ?? `${product.name}の詳細ページです。`,
+    offers: {
+      '@type': 'Offer',
+      price: product.price,
+      priceCurrency: 'JPY',
+      availability:
+        product.stock > 0
+          ? 'https://schema.org/InStock'
+          : 'https://schema.org/OutOfStock',
+      url: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products/${product.id}`,
+    },
   }
 
   // ログイン状態・レビュー済み確認
@@ -52,6 +86,11 @@ export default async function ProductDetailPage({ params }: Props) {
 
   return (
     <div>
+      {/* 追加: 商品の構造化データ（JSON-LD） */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(productJsonLd) }}
+      />
       <ProductDetail
         product={product}
         wishlistProps={{ isLoggedIn: !!userId, initialIsWishlisted }} // 追加

--- a/src/app/(shop)/products/[id]/page.tsx
+++ b/src/app/(shop)/products/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ReviewForm } from '@/components/features/review/ReviewForm'
 import { ReviewList } from '@/components/features/review/ReviewList'
 import { env } from '@/env' // 追加: 構造化データ用URL生成
 import { SITE_NAME, TWITTER_CARD_TYPE } from '@/constants/seo' // 追加
+import { safeJsonLd } from '@/lib/seo/jsonLd' // 追加: JSON-LD XSS対策
 
 // 追加: React.cacheでラップして1リクエスト内のDBクエリ重複を解消
 const getCachedProductById = cache(findProductById)
@@ -89,7 +90,8 @@ export default async function ProductDetailPage({ params }: Props) {
       {/* 追加: 商品の構造化データ（JSON-LD） */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(productJsonLd) }}
+        // 変更: safeJsonLd で '<' をエスケープし XSS / </script> 離脱を防止
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(productJsonLd) }}
       />
       <ProductDetail
         product={product}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,15 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { AuthSessionProvider } from '@/components/providers/AuthSessionProvider' // 追加
+import { env } from '@/env' // 追加: SEO用metadataBase
+import {
+  SITE_NAME,
+  SITE_DESCRIPTION,
+  SITE_LOCALE,
+  DEFAULT_OG_IMAGE,
+  TWITTER_CARD_TYPE,
+  ORGANIZATION_NAME,
+} from '@/constants/seo' // 追加
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -14,14 +23,41 @@ const geistMono = localFont({
   weight: "100 900",
 });
 
+// 追加: SEO拡充（OG/Twitter/metadataBase）
 export const metadata: Metadata = {
+  metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
   title: {
-    default: 'SampleShop',
-    template: '%s | SampleShop',
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
   },
-  description: '上質なアイテムをお届けするオンラインショップ',
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    type: 'website',
+    locale: SITE_LOCALE,
+    url: env.NEXT_PUBLIC_APP_URL,
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: {
+    card: TWITTER_CARD_TYPE,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE],
+  },
 };
 
+// 追加: Organization 構造化データ
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: ORGANIZATION_NAME,
+  url: env.NEXT_PUBLIC_APP_URL,
+  logo: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}${DEFAULT_OG_IMAGE}`,
+}
+
+// Next.js規約上 RootLayout は default export が必須のため例外的に使用
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -30,6 +66,12 @@ export default function RootLayout({
   return (
     <html lang="ja">{/* 変更: 日本語ECサイトのためja指定 */}
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        {/* 追加: Organization 構造化データ（JSON-LD） */}
+        <script
+          type="application/ld+json"
+          // JSON.stringify でエスケープされるためXSS安全
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
         {/* 追加: NextAuth v5 SessionProvider でラップ */}
         <AuthSessionProvider>
           {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
   TWITTER_CARD_TYPE,
   ORGANIZATION_NAME,
 } from '@/constants/seo' // 追加
+import { safeJsonLd } from '@/lib/seo/jsonLd' // 追加: JSON-LD XSS対策
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -69,8 +70,8 @@ export default function RootLayout({
         {/* 追加: Organization 構造化データ（JSON-LD） */}
         <script
           type="application/ld+json"
-          // JSON.stringify でエスケープされるためXSS安全
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+          // 変更: safeJsonLd で '<' をエスケープし XSS / </script> 離脱を防止
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(organizationJsonLd) }}
         />
         {/* 追加: NextAuth v5 SessionProvider でラップ */}
         <AuthSessionProvider>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,24 @@
+// robots.txt 生成（Next.js App Router 規約）
+// 注意: Next.js の規約上 robots.ts は default export が必須のため例外的に export default を使用
+import type { MetadataRoute } from 'next'
+import { env } from '@/env'
+import { DISALLOWED_PATHS } from '@/constants/seo'
+
+const robots = (): MetadataRoute.Robots => {
+  const baseUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [...DISALLOWED_PATHS],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}
+
+// Next.js規約上 default export が必須のため例外的に使用
+export default robots

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,51 @@
+// サイトマップ生成（Next.js App Router 規約）
+// 注意: Next.js の規約上 sitemap.ts は default export が必須のため例外的に export default を使用
+import type { MetadataRoute } from 'next'
+import { env } from '@/env'
+import { prisma } from '@/lib/db/prisma'
+import {
+  STATIC_SITEMAP_PATHS,
+  SITEMAP_CHANGE_FREQ,
+  SITEMAP_PRIORITY,
+} from '@/constants/seo'
+
+const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
+  const baseUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')
+
+  // 静的ページ
+  const staticEntries: MetadataRoute.Sitemap = STATIC_SITEMAP_PATHS.map((path) => ({
+    url: `${baseUrl}${path}`,
+    lastModified: new Date(),
+    changeFrequency:
+      path === '/'
+        ? SITEMAP_CHANGE_FREQ.HOME
+        : path === '/products'
+          ? SITEMAP_CHANGE_FREQ.PRODUCTS_LIST
+          : SITEMAP_CHANGE_FREQ.STATIC,
+    priority:
+      path === '/'
+        ? SITEMAP_PRIORITY.HOME
+        : path === '/products'
+          ? SITEMAP_PRIORITY.PRODUCTS_LIST
+          : SITEMAP_PRIORITY.STATIC,
+  }))
+
+  // 公開中の商品詳細ページ（DB直アクセスでパフォーマンス重視）
+  const products = await prisma.product.findMany({
+    where: { isPublished: true },
+    select: { id: true, updatedAt: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  const productEntries: MetadataRoute.Sitemap = products.map((p) => ({
+    url: `${baseUrl}/products/${p.id}`,
+    lastModified: p.updatedAt,
+    changeFrequency: SITEMAP_CHANGE_FREQ.PRODUCT_DETAIL,
+    priority: SITEMAP_PRIORITY.PRODUCT_DETAIL,
+  }))
+
+  return [...staticEntries, ...productEntries]
+}
+
+// Next.js規約上 default export が必須のため例外的に使用
+export default sitemap

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
   STATIC_SITEMAP_PATHS,
   SITEMAP_CHANGE_FREQ,
   SITEMAP_PRIORITY,
+  SITEMAP_MAX_PRODUCTS,
 } from '@/constants/seo'
 
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
@@ -31,10 +32,12 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   }))
 
   // 公開中の商品詳細ページ（DB直アクセスでパフォーマンス重視）
+  // 変更: sitemap が肥大化しないよう take で件数を制限し、新しいものから優先
   const products = await prisma.product.findMany({
     where: { isPublished: true },
     select: { id: true, updatedAt: true },
     orderBy: { updatedAt: 'desc' },
+    take: SITEMAP_MAX_PRODUCTS,
   })
 
   const productEntries: MetadataRoute.Sitemap = products.map((p) => ({

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -1,0 +1,41 @@
+// SEO関連の定数
+export const SITE_NAME = 'SampleShop'
+export const SITE_DESCRIPTION = '上質なアイテムをお届けするオンラインショップ'
+export const SITE_LOCALE = 'ja_JP'
+export const DEFAULT_OG_IMAGE = '/og-default.png' // public配下のデフォルトOG画像（未配置でも参照のみで問題なし）
+export const TWITTER_CARD_TYPE = 'summary_large_image' as const
+export const ORGANIZATION_NAME = SITE_NAME
+
+// sitemap用：sitemapに含める静的パス
+export const STATIC_SITEMAP_PATHS = [
+  '/',
+  '/products',
+  '/login',
+  '/register',
+  '/wishlist',
+] as const
+
+// robots.ts でクロール禁止とするパス
+export const DISALLOWED_PATHS = [
+  '/admin/',
+  '/api/',
+  '/checkout/',
+  '/account/',
+  '/orders/',
+  '/cart/',
+] as const
+
+// sitemap優先度・更新頻度
+export const SITEMAP_CHANGE_FREQ = {
+  HOME: 'daily',
+  PRODUCTS_LIST: 'daily',
+  PRODUCT_DETAIL: 'weekly',
+  STATIC: 'monthly',
+} as const
+
+export const SITEMAP_PRIORITY = {
+  HOME: 1.0,
+  PRODUCTS_LIST: 0.9,
+  PRODUCT_DETAIL: 0.8,
+  STATIC: 0.5,
+} as const

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -2,7 +2,9 @@
 export const SITE_NAME = 'SampleShop'
 export const SITE_DESCRIPTION = '上質なアイテムをお届けするオンラインショップ'
 export const SITE_LOCALE = 'ja_JP'
-export const DEFAULT_OG_IMAGE = '/og-default.png' // public配下のデフォルトOG画像（未配置でも参照のみで問題なし）
+// TODO: public/og-default.png を後日配置する。
+// 未配置の場合 OG 画像取得時に 404 となるため、本番デプロイ前に必ず画像を配置すること。
+export const DEFAULT_OG_IMAGE = '/og-default.png'
 export const TWITTER_CARD_TYPE = 'summary_large_image' as const
 export const ORGANIZATION_NAME = SITE_NAME
 
@@ -39,3 +41,6 @@ export const SITEMAP_PRIORITY = {
   PRODUCT_DETAIL: 0.8,
   STATIC: 0.5,
 } as const
+
+// sitemap に含める商品の最大件数（Google の sitemap.xml 上限 50,000 件を踏まえた安全値）
+export const SITEMAP_MAX_PRODUCTS = 10000

--- a/src/lib/seo/jsonLd.test.ts
+++ b/src/lib/seo/jsonLd.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { safeJsonLd } from './jsonLd'
+
+describe('safeJsonLd', () => {
+  it('通常の文字列はそのままJSONとしてシリアライズされる（"<"は含まれない）', () => {
+    const result = safeJsonLd({ name: 'SampleShop', price: 1000 })
+    expect(result).toBe('{"name":"SampleShop","price":1000}')
+    expect(result).not.toContain('<')
+  })
+
+  it('"</script>" を含む文字列は "<" がエスケープされHTMLパーサから離脱できない', () => {
+    const result = safeJsonLd({ description: '</script><script>alert(1)</script>' })
+    expect(result).not.toContain('</script>')
+    expect(result).not.toContain('<')
+    // '<' のみエスケープ（'>' はそのまま残るが HTML パーサ離脱には '<' があれば不可）
+    expect(result).toContain('\\u003c/script>')
+    // JSON として有効でありパース後の値は元のまま復元される
+    expect(JSON.parse(result)).toEqual({ description: '</script><script>alert(1)</script>' })
+  })
+
+  it('"<" や ">" を含む文字列の "<" は全てエスケープされる', () => {
+    const result = safeJsonLd({ html: '<div>hello</div>' })
+    expect(result).not.toContain('<')
+    expect(result).toContain('\\u003c')
+    expect(JSON.parse(result)).toEqual({ html: '<div>hello</div>' })
+  })
+
+  it('ネストオブジェクトの中の "<" もエスケープされる', () => {
+    const data = {
+      '@context': 'https://schema.org',
+      '@type': 'Product',
+      offers: {
+        '@type': 'Offer',
+        description: '<img src=x onerror=alert(1)>',
+      },
+    }
+    const result = safeJsonLd(data)
+    expect(result).not.toContain('<')
+    expect(JSON.parse(result)).toEqual(data)
+  })
+
+  it('"<" を含まないネストオブジェクトは通常のJSON.stringifyと同じ結果になる', () => {
+    const data = { a: { b: { c: [1, 2, 3] } } }
+    expect(safeJsonLd(data)).toBe(JSON.stringify(data))
+  })
+})

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -1,0 +1,5 @@
+// JSON-LD を <script> タグに安全に埋め込むためのヘルパー
+// JSON.stringify の結果に含まれる '<' をすべて Unicode エスケープすることで、
+// </script> による HTML パーサ離脱や XSS を防ぐ。
+export const safeJsonLd = (data: unknown): string =>
+  JSON.stringify(data).replace(/</g, '\\u003c')


### PR DESCRIPTION
## 概要
Issue #46 の実装。sitemap・robots・OGメタタグ・構造化データを整備。

## 変更内容
- `src/app/sitemap.ts` 追加（静的ページ + 公開商品全件）
- `src/app/robots.ts` 追加（admin/api/checkout 等を disallow）
- ルートレイアウトに OG/Twitter デフォルト + Organization JSON-LD
- 商品詳細に generateMetadata + Product JSON-LD（offers/availability）
- `src/constants/seo.ts` でサイト名・OG画像等を集約

Closes #46
