### PR TITLE
feat(admin): Cloudinary画像アップロード機能を実装 (#56)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    // 追加: Cloudinary 上の画像を next/image で表示できるよう許可
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        pathname: '/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@stripe/stripe-js": "^9.3.1",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
+    "cloudinary": "^2.10.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
     "next": "14.2.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
+      cloudinary:
+        specifier: ^2.10.0
+        version: 2.10.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1245,6 +1248,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cloudinary@2.10.0:
+    resolution: {integrity: sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==}
+    engines: {node: '>=9'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2095,6 +2102,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4191,6 +4201,10 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cloudinary@2.10.0:
+    dependencies:
+      lodash: 4.18.1
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -5143,6 +5157,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
 
   long@5.3.2: {}
 

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -26,14 +26,15 @@ export const PUT = async (
       return NextResponse.json({ error: '入力内容に誤りがあります', details: parsed.error.flatten() }, { status: 400 })
     }
 
-    const { name, description, price, stock, categoryId, isPublished } = parsed.data
+    const { name, description, price, stock, categoryId, isPublished, images } = parsed.data
     const product = await updateProduct(params.id, {
       name,
       description,
       price,
       stock,
       isPublished,
-      // TODO: 画像アップロード対応（Cloudinary or Vercel Blob）は未実装
+      // 変更: 画像URL配列を更新（Cloudinaryアップロード後のURLを受け取る）
+      images,
       ...(categoryId !== undefined
         ? { category: categoryId ? { connect: { id: categoryId } } : { disconnect: true } }
         : {}),

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -43,15 +43,15 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json({ error: '入力内容に誤りがあります', details: parsed.error.flatten() }, { status: 400 })
     }
 
-    const { name, description, price, stock, categoryId, isPublished } = parsed.data
+    const { name, description, price, stock, categoryId, isPublished, images } = parsed.data
     const product = await createProduct({
       name,
       description,
       price,
       stock,
       isPublished,
-      // TODO: 画像アップロード対応（Cloudinary or Vercel Blob）は未実装
-      images: [],
+      // 変更: 画像URL配列を保存（Cloudinaryアップロード後のURLを受け取る）
+      images,
       ...(categoryId ? { category: { connect: { id: categoryId } } } : {}),
     })
     return NextResponse.json({ product }, { status: 201 })

--- a/src/app/api/admin/upload/route.ts
+++ b/src/app/api/admin/upload/route.ts
@@ -1,0 +1,81 @@
+// 画像アップロード API（管理者専用）
+// POST: multipart/form-data で画像 1 ファイルを受け取り Cloudinary にアップロードする
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import { uploadImageBuffer } from '@/lib/cloudinary'
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_IMAGE_BYTES,
+  UPLOAD_ERROR_CODE,
+} from '@/constants/upload'
+
+export const runtime = 'nodejs'
+
+export const POST = async (req: Request) => {
+  // 管理者チェック
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json(
+      { error: check.error, code: UPLOAD_ERROR_CODE.UNAUTHORIZED },
+      { status: check.status },
+    )
+  }
+
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return NextResponse.json(
+      { error: 'multipart/form-data として読み込めませんでした', code: UPLOAD_ERROR_CODE.NO_FILE },
+      { status: 400 },
+    )
+  }
+
+  const file = formData.get('file')
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'fileフィールドにファイルを指定してください', code: UPLOAD_ERROR_CODE.NO_FILE },
+      { status: 400 },
+    )
+  }
+
+  // MIME タイプ検証
+  if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type as (typeof ALLOWED_IMAGE_MIME_TYPES)[number])) {
+    return NextResponse.json(
+      {
+        error: '対応していない画像形式です（jpeg/png/webp/gifのみ）',
+        code: UPLOAD_ERROR_CODE.INVALID_TYPE,
+      },
+      { status: 400 },
+    )
+  }
+
+  // サイズ検証
+  if (file.size > MAX_IMAGE_BYTES) {
+    return NextResponse.json(
+      {
+        error: `ファイルサイズが上限（${MAX_IMAGE_BYTES / 1024 / 1024}MB）を超えています`,
+        code: UPLOAD_ERROR_CODE.TOO_LARGE,
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+    const result = await uploadImageBuffer(buffer, file.name)
+    return NextResponse.json({
+      url: result.secureUrl,
+      publicId: result.publicId,
+      width: result.width,
+      height: result.height,
+    })
+  } catch (error) {
+    console.error('画像アップロードに失敗しました', error)
+    return NextResponse.json(
+      { error: '画像アップロードに失敗しました', code: UPLOAD_ERROR_CODE.UPLOAD_FAILED },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/admin/ImageUploader.tsx
+++ b/src/components/features/admin/ImageUploader.tsx
@@ -1,0 +1,139 @@
+'use client'
+// 画像アップローダーコンポーネント（管理画面・商品フォーム用）
+// Cloudinary に画像をアップロードしフォームの images 配列を更新する
+import { useState, useRef } from 'react'
+import Image from 'next/image'
+import { ALLOWED_IMAGE_MIME_TYPES, MAX_IMAGE_BYTES } from '@/constants/upload'
+
+type Props = {
+  // 現在の画像URL一覧
+  value: string[]
+  // 画像URL一覧の変更通知
+  onChange: (next: string[]) => void
+  // 同時に保持できる最大枚数
+  maxCount?: number
+}
+
+export const ImageUploader = ({ value, onChange, maxCount = 10 }: Props) => {
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // ファイル選択時の処理
+  const handleSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (!files || files.length === 0) return
+
+    setError(null)
+
+    // 上限チェック
+    if (value.length + files.length > maxCount) {
+      setError(`画像は最大${maxCount}枚までです`)
+      if (inputRef.current) inputRef.current.value = ''
+      return
+    }
+
+    setUploading(true)
+    try {
+      const uploaded: string[] = []
+      // 直列アップロード（Cloudinary 側のレート制限を考慮）
+      for (const file of Array.from(files)) {
+        // クライアント側でも MIME とサイズを軽く検証
+        if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type as (typeof ALLOWED_IMAGE_MIME_TYPES)[number])) {
+          throw new Error(`${file.name}: 対応していない画像形式です`)
+        }
+        if (file.size > MAX_IMAGE_BYTES) {
+          throw new Error(`${file.name}: ファイルサイズが上限を超えています`)
+        }
+
+        const formData = new FormData()
+        formData.append('file', file)
+        const res = await fetch('/api/admin/upload', {
+          method: 'POST',
+          body: formData,
+        })
+        if (!res.ok) {
+          const json: unknown = await res.json().catch(() => null)
+          const message =
+            json !== null &&
+            typeof json === 'object' &&
+            'error' in json &&
+            typeof (json as Record<string, unknown>).error === 'string'
+              ? (json as Record<string, unknown>).error
+              : 'アップロードに失敗しました'
+          throw new Error(String(message))
+        }
+        const json = (await res.json()) as { url: string }
+        uploaded.push(json.url)
+      }
+      onChange([...value, ...uploaded])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'アップロードに失敗しました')
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  // 画像を1枚削除
+  const handleRemove = (url: string) => {
+    onChange(value.filter((u) => u !== url))
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <label
+          htmlFor="image-uploader-input"
+          className="inline-flex cursor-pointer items-center rounded-md border bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+        >
+          {uploading ? 'アップロード中...' : '画像を追加'}
+        </label>
+        <input
+          ref={inputRef}
+          id="image-uploader-input"
+          type="file"
+          accept={ALLOWED_IMAGE_MIME_TYPES.join(',')}
+          multiple
+          onChange={handleSelect}
+          disabled={uploading || value.length >= maxCount}
+          className="sr-only"
+          aria-label="商品画像を選択"
+        />
+        <span className="text-xs text-muted-foreground">
+          {value.length} / {maxCount} 枚（jpeg/png/webp/gif・最大{MAX_IMAGE_BYTES / 1024 / 1024}MB）
+        </span>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-xs text-red-500">
+          {error}
+        </p>
+      )}
+
+      {value.length > 0 && (
+        <ul className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {value.map((url) => (
+            <li key={url} className="relative aspect-square overflow-hidden rounded-md border">
+              <Image
+                src={url}
+                alt="商品画像"
+                fill
+                sizes="(max-width: 640px) 50vw, 25vw"
+                className="object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(url)}
+                className="absolute right-1 top-1 rounded bg-black/60 px-2 py-1 text-xs text-white transition-opacity hover:bg-black/80"
+                aria-label="この画像を削除"
+              >
+                削除
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/admin/ProductForm.tsx
+++ b/src/components/features/admin/ProductForm.tsx
@@ -1,10 +1,11 @@
 'use client'
 // 商品フォームコンポーネント（新規作成・編集共用）
 import { useRouter } from 'next/navigation'
-import { useForm } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import type { Category } from '@/generated/prisma/client'
 import { productSchema, type ProductFormValues } from '@/lib/validators/product'
+import { ImageUploader } from '@/components/features/admin/ImageUploader'
 
 type Props = {
   // 編集時は初期値を渡す（新規作成時は undefined）
@@ -20,6 +21,7 @@ export const ProductForm = ({ defaultValues, productId, categories }: Props) => 
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors, isSubmitting },
   } = useForm<ProductFormValues>({
     resolver: zodResolver(productSchema),
@@ -30,6 +32,7 @@ export const ProductForm = ({ defaultValues, productId, categories }: Props) => 
       stock: 0,
       categoryId: '',
       isPublished: true,
+      images: [],
       ...defaultValues,
     },
   })
@@ -151,7 +154,20 @@ export const ProductForm = ({ defaultValues, productId, categories }: Props) => 
         </select>
       </div>
 
-      {/* TODO: 画像アップロード（Cloudinary or Vercel Blob）は未実装 */}
+      {/* 追加: 画像アップロード（Cloudinary連携） */}
+      <div className="space-y-1">
+        <p className="block text-sm font-medium">商品画像</p>
+        <Controller
+          control={control}
+          name="images"
+          render={({ field }) => (
+            <ImageUploader value={field.value ?? []} onChange={field.onChange} />
+          )}
+        />
+        {errors.images && (
+          <p role="alert" className="text-xs text-red-500">{errors.images.message}</p>
+        )}
+      </div>
 
       {/* 公開設定 */}
       <div className="flex items-center gap-3">

--- a/src/constants/upload.ts
+++ b/src/constants/upload.ts
@@ -1,0 +1,22 @@
+// 画像アップロード関連の定数
+// 許容する画像 MIME タイプ
+export const ALLOWED_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+] as const
+
+// 1ファイルあたりの最大バイト数（5MB）
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+// アップロード API のエラーコード
+export const UPLOAD_ERROR_CODE = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  NO_FILE: 'NO_FILE',
+  INVALID_TYPE: 'INVALID_TYPE',
+  TOO_LARGE: 'TOO_LARGE',
+  UPLOAD_FAILED: 'UPLOAD_FAILED',
+} as const
+
+export type UploadErrorCode = (typeof UPLOAD_ERROR_CODE)[keyof typeof UPLOAD_ERROR_CODE]

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,65 @@
+// Cloudinary SDK 設定
+import 'server-only'
+import { v2 as cloudinary } from 'cloudinary'
+import { env } from '@/env'
+
+// グローバル設定（モジュール初回読み込み時に1回のみ実行）
+cloudinary.config({
+  cloud_name: env.CLOUDINARY_CLOUD_NAME,
+  api_key: env.CLOUDINARY_API_KEY,
+  api_secret: env.CLOUDINARY_API_SECRET,
+  secure: true,
+})
+
+// 追加: アップロードフォルダ名（環境ごとに分ける場合はここで切替可能）
+const UPLOAD_FOLDER = 'sample-app/products'
+
+// 追加: アップロード結果の型（必要なフィールドのみ）
+export type CloudinaryUploadResult = {
+  secureUrl: string
+  publicId: string
+  width: number
+  height: number
+  format: string
+  bytes: number
+}
+
+// 追加: バッファ（File から作る Buffer）を Cloudinary にアップロードする
+export const uploadImageBuffer = async (
+  buffer: Buffer,
+  filename?: string,
+): Promise<CloudinaryUploadResult> => {
+  return new Promise((resolve, reject) => {
+    const uploadStream = cloudinary.uploader.upload_stream(
+      {
+        folder: UPLOAD_FOLDER,
+        resource_type: 'image',
+        // 既定は自動フォーマット最適化（webp/avif等を自動選択）
+        format: undefined,
+        public_id: filename ? sanitizePublicId(filename) : undefined,
+      },
+      (error, result) => {
+        if (error || !result) {
+          reject(error ?? new Error('Cloudinaryへのアップロードに失敗しました'))
+          return
+        }
+        resolve({
+          secureUrl: result.secure_url,
+          publicId: result.public_id,
+          width: result.width,
+          height: result.height,
+          format: result.format,
+          bytes: result.bytes,
+        })
+      },
+    )
+    uploadStream.end(buffer)
+  })
+}
+
+// 追加: ファイル名を public_id に使う場合の安全化
+const sanitizePublicId = (filename: string): string => {
+  // 拡張子を取り除き、英数字・ハイフン・アンダースコアのみに正規化
+  const base = filename.replace(/\.[^.]+$/, '')
+  return base.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80)
+}

--- a/src/lib/validators/product.ts
+++ b/src/lib/validators/product.ts
@@ -14,6 +14,10 @@ export const productSchema = z.object({
     .min(0, '在庫数は0以上で入力してください'),
   categoryId: z.string().optional(),
   isPublished: z.boolean(),
+  // 追加: 商品画像 URL 配列（最大10枚）
+  images: z
+    .array(z.string().url('画像URLの形式が不正です'))
+    .max(10, '画像は最大10枚までです'),
 })
 
 export type ProductFormValues = z.infer<typeof productSchema>


### PR DESCRIPTION
## 概要
Issue #56 を実装。商品管理画面でCloudinaryへの画像アップロードに対応。

## 変更点
- POST `/api/admin/upload` エンドポイント追加（管理者専用）
- `src/lib/cloudinary.ts` Cloudinary SDK ラッパー
- `ImageUploader` コンポーネント追加（複数枚対応・削除UI）
- `ProductForm` に画像アップローダー統合
- `next.config.mjs` に `res.cloudinary.com` を許可
- `productSchema` に `images` フィールド追加

## バリデーション
- 形式: jpeg/png/webp/gif
- サイズ: 5MB上限
- 枚数: 1商品あたり最大10枚

Closes #56