### PR TITLE
chore(ci): GitHub Actions CIパイプラインを追加 (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Lint / TypeCheck / Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      # ビルド・型チェック時にzodバリデーションを通すためのダミー環境変数
+      DATABASE_URL: postgresql://user:pass@localhost:5432/test
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ci-dummy-secret
+      STRIPE_SECRET_KEY: sk_test_dummy
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_dummy
+      STRIPE_WEBHOOK_SECRET: whsec_dummy
+      CLOUDINARY_CLOUD_NAME: dummy
+      CLOUDINARY_API_KEY: dummy
+      CLOUDINARY_API_SECRET: dummy
+      RESEND_API_KEY: re_dummy
+      EMAIL_FROM: onboarding@resend.dev
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm prisma generate
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Unit test
+        run: pnpm test

--- a/src/app/api/wishlist/route.ts
+++ b/src/app/api/wishlist/route.ts
@@ -14,7 +14,7 @@ const addWishlistSchema = z.object({
 })
 
 // GET /api/wishlist - ウィッシュリスト一覧取得（要認証）
-export const GET = async (_req: NextRequest) => {
+export const GET = async () => {
   const session = await auth()
   if (!session?.user?.id) {
     return NextResponse.json(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // 追加: Playwright E2E テストは Vitest の対象外（Playwright Runner で実行）
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 概要
Issue #57 を実装。PR/push時に自動でLint・型チェック・Vitestを実行するCIを追加。

## CI内容
- **Lint**: `pnpm lint`
- **TypeCheck**: `npx tsc --noEmit`
- **Unit Test**: `pnpm test` (Vitest)
- Node 20 + pnpm 10 / Prisma Client 自動生成

Closes #57