### PR TITLE
chore(deploy): Vercel本番デプロイ設定 (#60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="your_nextauth_secret_here"
 
 # Stripe
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..." # 変更: クライアントサイド参照のためNEXT_PUBLIC_プレフィックスを付与
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 STRIPE_SECRET_KEY="sk_test_..."
 STRIPE_WEBHOOK_SECRET="whsec_..."
 
@@ -17,7 +17,19 @@ CLOUDINARY_API_SECRET="your_api_secret"
 
 # Resend（メール送信）
 RESEND_API_KEY="re_..."
+EMAIL_FROM="onboarding@resend.dev"
 
 # アプリ設定
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 NODE_ENV="development"
+
+# Sentry（任意）
+# SENTRY_DSN=""
+# NEXT_PUBLIC_SENTRY_DSN=""
+# SENTRY_ENVIRONMENT="production"
+# SENTRY_ORG=""
+# SENTRY_PROJECT=""
+# SENTRY_AUTH_TOKEN=""
+
+# E2E（任意・seo.spec.ts等の有効化に使用）
+# E2E_BASE_URL="https://your-deployed-app.vercel.app"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,57 @@
+# 本番デプロイガイド（Vercel）
+
+## 環境変数チェックリスト
+
+Vercel ダッシュボードで以下を **Production / Preview / Development** ごとに設定する。
+
+### 必須
+
+| 変数名 | 用途 | 例 |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL 接続文字列 | `postgresql://user:pass@host:5432/db?schema=public&sslmode=require` |
+| `NEXTAUTH_URL` | デプロイ先URL | `https://your-app.vercel.app` |
+| `NEXTAUTH_SECRET` | NextAuth セッション署名 | `openssl rand -base64 32` で生成 |
+| `STRIPE_SECRET_KEY` | Stripe シークレット | `sk_live_...` |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe 公開キー | `pk_live_...` |
+| `STRIPE_WEBHOOK_SECRET` | Webhook署名シークレット | `whsec_...` |
+| `CLOUDINARY_CLOUD_NAME` | Cloudinary | - |
+| `CLOUDINARY_API_KEY` | Cloudinary | - |
+| `CLOUDINARY_API_SECRET` | Cloudinary | - |
+| `RESEND_API_KEY` | Resend API キー | `re_...` |
+| `EMAIL_FROM` | メール送信元 | `noreply@your-domain.com` |
+| `NEXT_PUBLIC_APP_URL` | 公開URL（sitemap等） | `https://your-app.vercel.app` |
+
+### 任意（Sentry）
+
+| 変数名 | 用途 |
+|---|---|
+| `SENTRY_DSN` | サーバーサイド DSN |
+| `NEXT_PUBLIC_SENTRY_DSN` | クライアントサイド DSN |
+| `SENTRY_ENVIRONMENT` | `production` / `staging` |
+| `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` | SourceMap アップロード時のみ |
+
+## デプロイ前チェック
+
+1. `pnpm install` が成功する
+2. `pnpm prisma generate` が成功する
+3. `pnpm lint` がエラー0
+4. `npx tsc --noEmit` がエラー0
+5. `pnpm test` が全件通過
+6. `pnpm build` が成功する（Vercel側で実行）
+
+## Stripe Webhook 設定
+
+1. Stripe Dashboard → Developers → Webhooks
+2. エンドポイント追加: `https://your-app.vercel.app/api/stripe/webhook`
+3. イベント: `payment_intent.succeeded`, `payment_intent.payment_failed`
+4. 取得した signing secret を `STRIPE_WEBHOOK_SECRET` に設定
+
+## Cloudinary 設定
+
+1. Cloudinary Dashboard で API キーを取得
+2. アップロードフォルダ: `sample-app/products`（コード側で固定）
+
+## 初回デプロイ後の確認
+
+- `/api/health` 等でアプリ起動確認（または `/`）
+- Prisma Migrate: 初回のみ `pnpm prisma migrate deploy` を Vercel 環境で実行

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -3,6 +3,9 @@ import { DashboardStats } from '@/components/features/admin/DashboardStats'
 import { RecentOrders } from '@/components/features/admin/RecentOrders'
 import { getDashboardStats, getRecentOrders } from '@/lib/db/stats'
 
+// 追加: 管理画面はDB必須のため動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
 export const metadata = {
   title: 'ダッシュボード | 管理画面',
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,9 @@ import {
   SITEMAP_MAX_PRODUCTS,
 } from '@/constants/seo'
 
+// 追加: ビルド時のDB接続を避けるため動的生成にする
+export const dynamic = 'force-dynamic'
+
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const baseUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "regions": ["hnd1"],
+  "buildCommand": "pnpm prisma generate && pnpm build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "functions": {
+    "src/app/api/stripe/webhook/route.ts": {
+      "maxDuration": 30
+    },
+    "src/app/api/admin/upload/route.ts": {
+      "maxDuration": 30
+    },
+    "src/app/api/orders/route.ts": {
+      "maxDuration": 20
+    }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
Issue #60 対応。Vercel本番デプロイのための設定とドキュメントを追加。

## 変更点
- `vercel.json`: framework=nextjs, region=hnd1, ビルドコマンド (prisma generate含む), 関数タイムアウト (webhook/upload=30s, orders=20s), セキュリティヘッダー
- `.env.example`: 本番デプロイに必要な環境変数を網羅 (Sentry等は任意としてコメントアウト)
- `docs/DEPLOYMENT.md`: 環境変数チェックリスト、Stripe/Cloudinary設定手順、prisma migrate deploy
- `sitemap.ts` / 管理ダッシュボード: ビルド時DB接続を避けるため `export const dynamic = 'force-dynamic'`

## 検証
- `pnpm build` ローカル成功
- CI: lint + tsc + test

Closes #60