### PR TITLE
test(api): Route Handler の Integration テスト追加 (#61)

### DIFF
--- a/src/app/api/auth/register/route.test.ts
+++ b/src/app/api/auth/register/route.test.ts
@@ -1,0 +1,70 @@
+// 追加: 会員登録 Route Handler の Integration テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// 依存モック
+vi.mock('@/lib/db/users', () => ({
+  findUserByEmail: vi.fn(),
+  createUser: vi.fn(),
+}))
+vi.mock('bcryptjs', () => ({
+  default: { hash: vi.fn().mockResolvedValue('hashed') },
+}))
+vi.mock('@/lib/rateLimit', () => ({
+  enforceRateLimit: vi.fn().mockReturnValue(null),
+}))
+
+import { POST } from './route'
+import { findUserByEmail, createUser } from '@/lib/db/users'
+import { enforceRateLimit } from '@/lib/rateLimit'
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost/api/auth/register', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(enforceRateLimit).mockReturnValue(null)
+  })
+
+  it('正常系: 201 を返し、ユーザーを作成する', async () => {
+    vi.mocked(findUserByEmail).mockResolvedValue(null)
+    vi.mocked(createUser).mockResolvedValue({ id: 'u1' } as never)
+
+    const res = await POST(
+      makeRequest({ email: 'test@example.com', name: 'Test', password: 'password123' }),
+    )
+    expect(res.status).toBe(201)
+    expect(createUser).toHaveBeenCalledOnce()
+  })
+
+  it('バリデーションエラー: 不正な入力で 400 を返す', async () => {
+    const res = await POST(makeRequest({ email: 'invalid', name: '', password: '1' }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('重複エラー: 既存メールで 409 を返す', async () => {
+    vi.mocked(findUserByEmail).mockResolvedValue({ id: 'u1' } as never)
+    const res = await POST(
+      makeRequest({ email: 'dup@example.com', name: 'Test', password: 'password123' }),
+    )
+    expect(res.status).toBe(409)
+    const json = await res.json()
+    expect(json.code).toBe('EMAIL_ALREADY_EXISTS')
+  })
+
+  it('レート制限: 制限超過で enforceRateLimit のレスポンスを返す', async () => {
+    const limitRes = new Response(JSON.stringify({ error: 'rate limit' }), { status: 429 })
+    vi.mocked(enforceRateLimit).mockReturnValue(limitRes as never)
+    const res = await POST(
+      makeRequest({ email: 'test@example.com', name: 'Test', password: 'password123' }),
+    )
+    expect(res.status).toBe(429)
+  })
+})

--- a/src/app/api/orders/route.test.ts
+++ b/src/app/api/orders/route.test.ts
@@ -1,0 +1,94 @@
+// 追加: 注文 Route Handler の Integration テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/lib/db/orders', () => ({
+  createOrder: vi.fn(),
+  findOrdersByUserId: vi.fn(),
+}))
+vi.mock('@/lib/db/products', () => ({
+  validateCartItems: vi.fn(),
+}))
+vi.mock('@/lib/db/coupons', () => ({
+  findCouponByCode: vi.fn(),
+  incrementCouponUsedCountAtomic: vi.fn(),
+}))
+vi.mock('@/lib/email/sendOrderConfirmation', () => ({
+  sendOrderConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/rateLimit', () => ({
+  enforceRateLimit: vi.fn().mockReturnValue(null),
+}))
+
+import { GET, POST } from './route'
+import { auth } from '@/lib/auth'
+import { findOrdersByUserId, createOrder } from '@/lib/db/orders'
+import { validateCartItems } from '@/lib/db/products'
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost/api/orders', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('GET /api/orders', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('未認証時は 401 を返す', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('認証済みなら注文一覧を返す', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'u1' } } as never)
+    vi.mocked(findOrdersByUserId).mockResolvedValue([{ id: 'o1' }] as never)
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.orders).toHaveLength(1)
+  })
+})
+
+describe('POST /api/orders', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('未認証時は 401 を返す', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const res = await POST(makeRequest({ items: [{ id: 'p1', quantity: 1 }] }))
+    expect(res.status).toBe(401)
+  })
+
+  it('items 不正で 400 を返す', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'u1' } } as never)
+    const res = await POST(makeRequest({ items: [] }))
+    expect(res.status).toBe(400)
+  })
+
+  it('正常系: 注文を作成し 201 相当を返す', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'u1' } } as never)
+    vi.mocked(validateCartItems).mockResolvedValue([
+      { product: { id: 'p1', price: 1000, stock: 10, name: 'P' }, quantity: 2 },
+    ] as never)
+    vi.mocked(createOrder).mockResolvedValue({ id: 'o1' } as never)
+
+    const res = await POST(
+      makeRequest({
+        items: [{ id: 'p1', quantity: 2 }],
+        shippingAddress: {
+          postalCode: '100-0001',
+          prefecture: '東京都',
+          city: '千代田区',
+          address: '1-1',
+          name: 'Test',
+          phone: '09000000000',
+        },
+        stripePaymentIntentId: 'pi_test',
+      }),
+    )
+    expect([200, 201]).toContain(res.status)
+    expect(createOrder).toHaveBeenCalledOnce()
+  })
+})

--- a/src/app/api/products/route.test.ts
+++ b/src/app/api/products/route.test.ts
@@ -1,0 +1,50 @@
+// 追加: 商品 Route Handler の Integration テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db/products', () => ({
+  findProducts: vi.fn(),
+}))
+
+import { GET } from './route'
+import { findProducts } from '@/lib/db/products'
+
+const makeRequest = (url: string) => new NextRequest(url)
+
+describe('GET /api/products', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('正常系: クエリ無しでデフォルト件数の商品一覧を返す', async () => {
+    vi.mocked(findProducts).mockResolvedValue([{ id: 'p1' }] as never)
+    const res = await GET(makeRequest('http://localhost/api/products'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toHaveLength(1)
+    expect(findProducts).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'desc' } }),
+    )
+  })
+
+  it('search・sort=price_asc クエリが正しく渡る', async () => {
+    vi.mocked(findProducts).mockResolvedValue([] as never)
+    await GET(makeRequest('http://localhost/api/products?search=foo&sort=price_asc'))
+    expect(findProducts).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'foo', orderBy: { price: 'asc' } }),
+    )
+  })
+
+  it('take の上限超過は MAX_TAKE に丸められる', async () => {
+    vi.mocked(findProducts).mockResolvedValue([] as never)
+    await GET(makeRequest('http://localhost/api/products?take=99999'))
+    const call = vi.mocked(findProducts).mock.calls[0][0]
+    expect(call.take).toBeLessThanOrEqual(100)
+  })
+
+  it('DBエラー時は 500 を返す', async () => {
+    vi.mocked(findProducts).mockRejectedValue(new Error('boom'))
+    const res = await GET(makeRequest('http://localhost/api/products'))
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## 概要
Issue #61 対応。主要 Route Handler の Vitest Integration テストを追加。

## 追加テスト (計13件)
- `/api/auth/register`: 正常系/バリデーション/重複/レート制限 (4 tests)
- `/api/products`: 正常系/クエリ/take上限/エラー (4 tests)
- `/api/orders`: GET 認証 + POST 認証/バリデーション/正常系 (5 tests)

## 検証
- `pnpm vitest run src/app/api` 全パス

Closes #61