### PR TITLE
perf: next/dynamic コード分割によるパフォーマンス改善 (#62)

### DIFF
--- a/src/app/(admin)/admin/products/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/products/[id]/edit/page.tsx
@@ -6,6 +6,9 @@ import { ProductForm } from '@/components/features/admin/ProductForm'
 import { findProductByIdForAdmin } from '@/lib/db/products'
 import { findAllCategories } from '@/lib/db/categories'
 
+// 追加: 管理画面はDB必須のため動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
 export const metadata = {
   title: '商品編集 | 管理画面',
 }

--- a/src/app/(admin)/admin/products/new/page.tsx
+++ b/src/app/(admin)/admin/products/new/page.tsx
@@ -4,6 +4,9 @@ import { ChevronLeft } from 'lucide-react'
 import { ProductForm } from '@/components/features/admin/ProductForm'
 import { findAllCategories } from '@/lib/db/categories'
 
+// 追加: 管理画面はDB必須のため動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
 export const metadata = {
   title: '商品新規作成 | 管理画面',
 }

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -4,6 +4,9 @@ import { Plus } from 'lucide-react'
 import { ProductTable } from '@/components/features/admin/ProductTable'
 import { findAllProductsForAdmin } from '@/lib/db/products'
 
+// 追加: 管理画面はDB必須のため動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
 export const metadata = {
   title: '商品管理 | 管理画面',
 }

--- a/src/app/(shop)/checkout/page.tsx
+++ b/src/app/(shop)/checkout/page.tsx
@@ -2,10 +2,31 @@
 // チェックアウトページ（認証チェック + PaymentIntent 取得 + Stripe Elements レンダリング）
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Elements } from '@stripe/react-stripe-js'
+import dynamic from 'next/dynamic' // 追加
 import { loadStripe } from '@stripe/stripe-js'
-import { CheckoutForm } from '@/components/features/checkout/CheckoutForm'
 import { useCartStore } from '@/stores/cartStore'
+
+// 追加: Stripe Elements と CheckoutForm を遅延読み込みして初期バンドルを削減
+const Elements = dynamic(
+  () => import('@stripe/react-stripe-js').then((mod) => mod.Elements),
+  { ssr: false },
+)
+const CheckoutForm = dynamic(
+  () =>
+    import('@/components/features/checkout/CheckoutForm').then((mod) => ({
+      default: mod.CheckoutForm,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-4 animate-pulse">
+        <div className="h-10 rounded bg-muted" />
+        <div className="h-10 rounded bg-muted" />
+        <div className="h-32 rounded bg-muted" />
+      </div>
+    ),
+  },
+)
 
 // Stripe publishable key（クライアントサイド）
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '')

--- a/src/components/features/admin/ProductForm.tsx
+++ b/src/components/features/admin/ProductForm.tsx
@@ -3,9 +3,21 @@
 import { useRouter } from 'next/navigation'
 import { Controller, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import dynamic from 'next/dynamic' // 追加
 import type { Category } from '@/generated/prisma/client'
 import { productSchema, type ProductFormValues } from '@/lib/validators/product'
-import { ImageUploader } from '@/components/features/admin/ImageUploader'
+
+// 追加: ImageUploader は Cloudinary アップロード処理を含み重いため遅延読み込み
+const ImageUploader = dynamic(
+  () =>
+    import('@/components/features/admin/ImageUploader').then((mod) => ({
+      default: mod.ImageUploader,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="h-32 animate-pulse rounded-md bg-muted" aria-label="読み込み中" />,
+  },
+)
 
 type Props = {
   // 編集時は初期値を渡す（新規作成時は undefined）


### PR DESCRIPTION
## 概要
Issue #62 対応。重いクライアントコンポーネントを `next/dynamic` で遅延読み込みし、初期バンドルを削減。

## 変更点
- `src/app/(shop)/checkout/page.tsx`: `@stripe/react-stripe-js` の `Elements` および `CheckoutForm` を `next/dynamic` (ssr: false) で遅延読み込み
- `src/components/features/admin/ProductForm.tsx`: `ImageUploader` (Cloudinary 関連) を遅延読み込み
- `src/app/(admin)/admin/products/{page,new/page,[id]/edit/page}.tsx`: ビルド時 DB 接続を避けるため `force-dynamic` を追加

## 効果（pnpm build 比較）
- `/checkout` First Load JS: **140 kB → 92.6 kB** (約34%削減)

## 検証
- `pnpm build` 成功
- CI: lint + tsc + test 通過

Closes #62