### PR TITLE
test(e2e): E2E テスト拡充 (#70)

### DIFF
--- a/e2e/admin-management.spec.ts
+++ b/e2e/admin-management.spec.ts
@@ -1,0 +1,33 @@
+// 追加: 管理画面 注文ステータス変更・レビュー公開切り替えの E2E テスト
+// 注意: 管理者ロールでのログインと DB が必要なため test.fixme() でマーク
+import { test, expect } from '@playwright/test'
+
+test.describe('管理画面 注文管理', () => {
+  test.fixme('注文ステータスを SHIPPED に変更できる', async ({ page }) => {
+    await page.goto('/admin/orders')
+    await expect(page.getByRole('heading', { name: /注文管理/ })).toBeVisible()
+
+    // 最初の注文の詳細へ
+    const firstOrderLink = page.getByRole('link', { name: /詳細|表示/ }).first()
+    await firstOrderLink.click()
+
+    // ステータス変更
+    await page.getByLabel(/ステータス/).selectOption('SHIPPED')
+    await page.getByRole('button', { name: /更新|保存/ }).click()
+
+    await expect(page.getByText(/SHIPPED|発送済み/)).toBeVisible()
+  })
+})
+
+test.describe('管理画面 レビュー管理', () => {
+  test.fixme('レビューの公開/非公開を切り替えられる', async ({ page }) => {
+    await page.goto('/admin/reviews')
+    await expect(page.getByRole('heading', { name: /レビュー管理/ })).toBeVisible()
+
+    const toggleBtn = page.getByRole('button', { name: /公開|非公開/ }).first()
+    await toggleBtn.click()
+
+    // トースト or 状態変化を確認
+    await expect(toggleBtn).toBeVisible()
+  })
+})

--- a/e2e/coupon-checkout.spec.ts
+++ b/e2e/coupon-checkout.spec.ts
@@ -1,0 +1,25 @@
+// 追加: クーポン適用フローの E2E テスト
+// チェックアウト画面でコードを入力 → 割引反映 → 注文確定
+// 注意: DB / Stripe / クーポンマスタが必要なため test.fixme() でマーク
+import { test, expect } from '@playwright/test'
+
+test.describe('クーポン適用', () => {
+  test.fixme('有効なクーポンコードを入力すると割引が反映される', async ({ page }) => {
+    // 事前にカートに商品を入れた状態を想定
+    await page.goto('/checkout')
+
+    // クーポンコード入力欄
+    await page.getByLabel(/クーポンコード/).fill('SAMPLE10')
+    await page.getByRole('button', { name: /適用|apply/i }).click()
+
+    // 割引行が表示される
+    await expect(page.getByText(/割引/)).toBeVisible()
+  })
+
+  test.fixme('無効なクーポンコードはエラーメッセージを表示する', async ({ page }) => {
+    await page.goto('/checkout')
+    await page.getByLabel(/クーポンコード/).fill('INVALID-CODE')
+    await page.getByRole('button', { name: /適用|apply/i }).click()
+    await expect(page.getByText(/無効|使用できません/)).toBeVisible()
+  })
+})

--- a/e2e/review.spec.ts
+++ b/e2e/review.spec.ts
@@ -1,0 +1,33 @@
+// 追加: レビュー投稿フローの E2E テスト
+// 商品詳細ページから星評価とコメントを投稿し、表示を確認する
+// 注意: DB / 認証セッションが必要なため test.fixme() でマーク（実環境で有効化）
+import { test, expect } from '@playwright/test'
+
+test.describe('レビュー投稿', () => {
+  test.fixme('ログイン後に星評価とコメントを投稿できる', async ({ page }) => {
+    // 事前にログイン済みであることを想定
+    await page.goto('/products')
+    const firstCard = page.getByRole('link', { name: /の詳細を見る/ }).first()
+    await firstCard.click()
+
+    // レビューフォームの星評価（5つ星）を選択
+    await page.getByRole('button', { name: '星5' }).click()
+
+    // コメント入力
+    await page.getByLabel(/コメント|レビュー本文/).fill('期待以上の品質でした')
+
+    // 投稿ボタン
+    await page.getByRole('button', { name: /投稿|送信/ }).click()
+
+    // 投稿後にレビュー一覧に表示される
+    await expect(page.getByText('期待以上の品質でした')).toBeVisible()
+  })
+
+  test.fixme('未ログインの場合はレビューフォームが表示されない', async ({ page }) => {
+    await page.goto('/products')
+    const firstCard = page.getByRole('link', { name: /の詳細を見る/ }).first()
+    await firstCard.click()
+    // フォームが存在しない or ログイン誘導が表示される
+    await expect(page.getByRole('button', { name: /投稿|送信/ })).toHaveCount(0)
+  })
+})

--- a/e2e/wishlist.spec.ts
+++ b/e2e/wishlist.spec.ts
@@ -1,0 +1,33 @@
+// 追加: ウィッシュリストの E2E テスト
+// 商品詳細から追加 → /wishlist で確認 → 削除
+// 注意: DB / 認証が必要なため test.fixme() でマーク
+import { test, expect } from '@playwright/test'
+
+test.describe('ウィッシュリスト', () => {
+  test.fixme('商品詳細から追加して /wishlist で確認できる', async ({ page }) => {
+    await page.goto('/products')
+    const firstCard = page.getByRole('link', { name: /の詳細を見る/ }).first()
+    await firstCard.click()
+
+    // ウィッシュリスト追加ボタン
+    await page.getByRole('button', { name: /お気に入りに追加|ウィッシュリスト/ }).click()
+
+    await page.goto('/wishlist')
+    await expect(page.getByRole('heading', { name: /ウィッシュリスト|お気に入り/ })).toBeVisible()
+    // 少なくとも1件表示
+    await expect(page.getByRole('link', { name: /の詳細を見る/ }).first()).toBeVisible()
+  })
+
+  test.fixme('ウィッシュリストから商品を削除できる', async ({ page }) => {
+    await page.goto('/wishlist')
+    const removeBtn = page.getByRole('button', { name: /削除|外す/ }).first()
+    await removeBtn.click()
+    // 削除後は項目数が減るか、空の状態が表示される
+    await expect(page.getByText(/まだ追加されていません|空です/)).toBeVisible()
+  })
+
+  test.fixme('未ログインで /wishlist にアクセスするとログインページへリダイレクト', async ({ page }) => {
+    await page.goto('/wishlist')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})


### PR DESCRIPTION
## 概要
Issue #70 対応。レビュー・ウィッシュリスト・クーポン適用・管理画面の主要シナリオの E2E テストを追加。

## 追加ファイル
- `e2e/review.spec.ts`
- `e2e/wishlist.spec.ts`
- `e2e/coupon-checkout.spec.ts`
- `e2e/admin-management.spec.ts`

## 補足
DB・認証セッション・Stripe 等の外部要件があるため、既存の `purchase-flow.spec.ts` / `auth.spec.ts` と同様に `test.fixme()` でスキップマーク。実環境（テスト用 DB / シードデータ）が整い次第、fixme を外して有効化する想定。

Closes #70