### PR TITLE
ci(lighthouse): Lighthouse CI 導入 (#72)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,67 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+# CI ワークフロー全体の権限を最小化
+permissions:
+  contents: read
+
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm prisma generate
+
+      - name: Build
+        # Lighthouse 用にダミー環境変数を注入してビルドを通す
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost:5432/db
+          NEXTAUTH_SECRET: dummy-secret-for-build
+          NEXTAUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_APP_URL: http://localhost:3000
+          STRIPE_SECRET_KEY: sk_test_dummy
+          STRIPE_WEBHOOK_SECRET: whsec_dummy
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_dummy
+          CLOUDINARY_CLOUD_NAME: dummy
+          CLOUDINARY_API_KEY: dummy
+          CLOUDINARY_API_SECRET: dummy
+          RESEND_API_KEY: re_dummy
+          EMAIL_FROM: noreply@example.com
+        run: pnpm build
+
+      - name: Run Lighthouse CI
+        run: |
+          pnpm dlx @lhci/cli@0.14.x autorun --config=./lighthouserc.cjs || echo "LHCI 警告あり"
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost:5432/db
+          NEXTAUTH_SECRET: dummy-secret-for-build
+          NEXTAUTH_URL: http://localhost:3000
+          NEXT_PUBLIC_APP_URL: http://localhost:3000
+          STRIPE_SECRET_KEY: sk_test_dummy
+          STRIPE_WEBHOOK_SECRET: whsec_dummy
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_dummy
+          CLOUDINARY_CLOUD_NAME: dummy
+          CLOUDINARY_API_KEY: dummy
+          CLOUDINARY_API_SECRET: dummy
+          RESEND_API_KEY: re_dummy
+          EMAIL_FROM: noreply@example.com

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,0 +1,35 @@
+// 追加: Lighthouse CI 設定
+// 主要ページの Performance / Accessibility / SEO / Best Practices を計測する
+module.exports = {
+  ci: {
+    collect: {
+      // CI で Next.js のプロダクションサーバを自動起動して計測する
+      startServerCommand: 'pnpm start',
+      startServerReadyPattern: 'Ready in',
+      startServerReadyTimeout: 60_000,
+      // DB 不要な静的ページに限定（CI 環境に DB が無いため）
+      url: [
+        'http://localhost:3000/',
+        'http://localhost:3000/login',
+        'http://localhost:3000/register',
+      ],
+      numberOfRuns: 1,
+      settings: {
+        chromeFlags: '--no-sandbox',
+      },
+    },
+    upload: {
+      // PR ごとに一時的な公開ストレージへ結果をアップロード
+      target: 'temporary-public-storage',
+    },
+    assert: {
+      assertions: {
+        // 閾値割れは warning（CI 全体は fail させない）
+        'categories:performance': ['warn', { minScore: 0.8 }],
+        'categories:accessibility': ['warn', { minScore: 0.95 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 概要
Issue #72 対応。PR ごとに Lighthouse スコアを計測してパフォーマンス・a11y・SEO のリグレッションを検知。

## 追加ファイル
- `lighthouserc.cjs`: 計測 URL と閾値設定（warn）
  - Performance ≥ 0.8 / Accessibility ≥ 0.95 / Best-Practices ≥ 0.9 / SEO ≥ 0.9
- `.github/workflows/lighthouse.yml`: PR トリガで build → start → @lhci/cli autorun

## 補足
- 計測対象は DB 不要な `/`・`/login`・`/register`（CI に DB が無いため）
- 結果は temporary-public-storage に公開（30日間有効）
- 閾値割れは warning にしてメインの Lint/Test ジョブをブロックしない

Closes #72