### PR TITLE
feat(seo): JSON-LD 拡充と動的 OGP 画像追加 (#73)

### DIFF
--- a/src/app/(shop)/products/[id]/opengraph-image.tsx
+++ b/src/app/(shop)/products/[id]/opengraph-image.tsx
@@ -1,0 +1,62 @@
+// 追加: 商品詳細ページの動的 OGP 画像
+// 商品名と価格を中心に表示する。商品画像は edge runtime + 外部URL の制約で省略。
+import { ImageResponse } from 'next/og'
+import { findProductById } from '@/lib/db/products'
+import { SITE_NAME } from '@/constants/seo'
+
+// edge runtime は Prisma が動かないため Node.js runtime を使用
+export const runtime = 'nodejs'
+export const alt = '商品ページ'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+type Props = {
+  params: { id: string }
+}
+
+const Image = async ({ params }: Props) => {
+  const product = await findProductById(params.id)
+
+  const name = product?.name ?? '商品'
+  const price = product ? `¥${product.price.toLocaleString()}` : ''
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#ffffff',
+          color: '#1a1a1a',
+          fontFamily: 'sans-serif',
+          padding: 80,
+        }}
+      >
+        <div style={{ fontSize: 28, color: '#666666', marginBottom: 32 }}>{SITE_NAME}</div>
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            textAlign: 'center',
+            lineHeight: 1.2,
+            letterSpacing: -1,
+          }}
+        >
+          {name}
+        </div>
+        {price && (
+          <div style={{ marginTop: 48, fontSize: 56, fontWeight: 600, color: '#1a1a1a' }}>
+            {price}
+          </div>
+        )}
+      </div>
+    ),
+    { ...size },
+  )
+}
+
+export default Image

--- a/src/app/(shop)/products/[id]/page.tsx
+++ b/src/app/(shop)/products/[id]/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next'
 import { auth } from '@/lib/auth'
 import { findProductById } from '@/lib/db/products'
 import { findReviewByUserAndProduct } from '@/lib/db/reviews'
+import { getReviewStatsByProductId } from '@/lib/db/reviews' // 追加: aggregateRating用
 import { isProductInWishlist } from '@/lib/db/wishlist' // 追加
 import { ProductDetail } from '@/components/features/product/ProductDetail'
 import { ReviewForm } from '@/components/features/review/ReviewForm'
@@ -59,6 +60,9 @@ export default async function ProductDetailPage({ params }: Props) {
   }
 
   // 追加: 商品 構造化データ（JSON-LD）
+  // 追加: レビュー集計を取得し aggregateRating を埋め込む
+  const reviewStats = await getReviewStatsByProductId(product.id)
+  const productUrl = `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products/${product.id}`
   const productJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Product',
@@ -73,8 +77,44 @@ export default async function ProductDetailPage({ params }: Props) {
         product.stock > 0
           ? 'https://schema.org/InStock'
           : 'https://schema.org/OutOfStock',
-      url: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products/${product.id}`,
+      url: productUrl,
     },
+    // 追加: レビューがある場合のみ aggregateRating を埋め込む
+    ...(reviewStats.count > 0
+      ? {
+          aggregateRating: {
+            '@type': 'AggregateRating',
+            ratingValue: reviewStats.average.toFixed(1),
+            reviewCount: reviewStats.count,
+          },
+        }
+      : {}),
+  }
+
+  // 追加: パンくずの構造化データ
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'トップ',
+        item: env.NEXT_PUBLIC_APP_URL,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: '商品一覧',
+        item: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: product.name,
+        item: productUrl,
+      },
+    ],
   }
 
   // ログイン状態・レビュー済み確認
@@ -92,6 +132,11 @@ export default async function ProductDetailPage({ params }: Props) {
         type="application/ld+json"
         // 変更: safeJsonLd で '<' をエスケープし XSS / </script> 離脱を防止
         dangerouslySetInnerHTML={{ __html: safeJsonLd(productJsonLd) }}
+      />
+      {/* 追加: パンくずの構造化データ */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }}
       />
       <ProductDetail
         product={product}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,19 @@ const organizationJsonLd = {
   logo: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}${DEFAULT_OG_IMAGE}`,
 }
 
+// 追加: WebSite 構造化データ（サイト内検索の SearchAction を含む）
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_NAME,
+  url: env.NEXT_PUBLIC_APP_URL,
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: `${env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')}/products?search={search_term_string}`,
+    'query-input': 'required name=search_term_string',
+  },
+}
+
 // Next.js規約上 RootLayout は default export が必須のため例外的に使用
 export default function RootLayout({
   children,
@@ -72,6 +85,11 @@ export default function RootLayout({
           type="application/ld+json"
           // 変更: safeJsonLd で '<' をエスケープし XSS / </script> 離脱を防止
           dangerouslySetInnerHTML={{ __html: safeJsonLd(organizationJsonLd) }}
+        />
+        {/* 追加: WebSite 構造化データ（サイト内検索 SearchAction） */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(websiteJsonLd) }}
         />
         {/* 追加: NextAuth v5 SessionProvider でラップ */}
         <AuthSessionProvider>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,34 @@
+// 追加: トップページの動的 OGP 画像
+// Next.js App Router の opengraph-image 規約で生成される
+import { ImageResponse } from 'next/og'
+import { SITE_NAME, SITE_DESCRIPTION } from '@/constants/seo'
+
+export const runtime = 'edge'
+export const alt = SITE_NAME
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+const Image = () =>
+  new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #1a1a1a 0%, #404040 100%)',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: -2 }}>{SITE_NAME}</div>
+        <div style={{ marginTop: 24, fontSize: 32, color: '#cccccc' }}>{SITE_DESCRIPTION}</div>
+      </div>
+    ),
+    { ...size },
+  )
+
+export default Image


### PR DESCRIPTION
## 概要
Issue #73 対応。検索エンジン最適化とソーシャル共有を強化。

## 変更点
### 構造化データ (JSON-LD)
- 商品詳細: `aggregateRating` (`getReviewStatsByProductId` のレビュー集計から動的生成) を追加
- 商品詳細: `BreadcrumbList` を追加 (トップ → 商品一覧 → 商品名)
- ルートレイアウト: `WebSite` schema + `SearchAction` (サイト内検索) を追加

### 動的 OGP 画像 (next/og ImageResponse)
- `src/app/opengraph-image.tsx`: トップ用 (edge runtime)
- `src/app/(shop)/products/[id]/opengraph-image.tsx`: 商品名・価格表示 (Prisma 利用のため Node.js runtime)

## 検証
- 型チェック・Lint 通過
- Google リッチリザルトテストでの検証は本番デプロイ後に実施

Closes #73