### PR TITLE
feat(admin): 注文・売上 CSV エクスポート (#74)

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -15,9 +15,28 @@ export default async function DashboardPage() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">ダッシュボード</h1>
-        <p className="text-sm text-muted-foreground">売上・注文の概要</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">ダッシュボード</h1>
+          <p className="text-sm text-muted-foreground">売上・注文の概要</p>
+        </div>
+        {/* 追加: 売上サマリ CSV ダウンロード (#74) */}
+        <div className="flex gap-2">
+          <a
+            href="/api/admin/export/sales?granularity=daily"
+            className="inline-flex items-center rounded-md border bg-background px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent"
+            aria-label="売上サマリ（日次）を CSV ダウンロード"
+          >
+            日次CSV
+          </a>
+          <a
+            href="/api/admin/export/sales?granularity=monthly"
+            className="inline-flex items-center rounded-md border bg-background px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent"
+            aria-label="売上サマリ（月次）を CSV ダウンロード"
+          >
+            月次CSV
+          </a>
+        </div>
       </div>
 
       {/* 統計カード */}

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -38,9 +38,19 @@ export default async function AdminOrdersPage({ searchParams }: Props) {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">注文管理</h1>
-        <p className="text-sm text-muted-foreground">注文の一覧・詳細確認・ステータス変更</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">注文管理</h1>
+          <p className="text-sm text-muted-foreground">注文の一覧・詳細確認・ステータス変更</p>
+        </div>
+        {/* 追加: CSV エクスポートボタン (#74) */}
+        <a
+          href="/api/admin/export/orders"
+          className="inline-flex items-center rounded-md border bg-background px-3 py-2 text-sm font-medium shadow-sm hover:bg-accent"
+          aria-label="注文一覧を CSV ダウンロード"
+        >
+          CSV ダウンロード
+        </a>
       </div>
 
       <Suspense fallback={<p className="text-sm text-muted-foreground">読み込み中...</p>}>

--- a/src/app/api/admin/export/orders/route.ts
+++ b/src/app/api/admin/export/orders/route.ts
@@ -1,0 +1,114 @@
+// 追加: 管理画面 注文一覧 CSV エクスポート API
+// GET /api/admin/export/orders?from=YYYY-MM-DD&to=YYYY-MM-DD
+// 管理者ロール必須。Excel 互換のため UTF-8 BOM 付き CSV を返す。
+import 'server-only'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db/prisma'
+import { requireAdmin } from '@/lib/admin-auth'
+import { toCsvWithBom } from '@/lib/csv'
+
+const ORDER_CSV_HEADERS = [
+  '注文ID',
+  '注文日時',
+  'ユーザーID',
+  'メールアドレス',
+  '氏名',
+  'ステータス',
+  '商品ID',
+  '商品名',
+  '単価',
+  '数量',
+  '小計',
+  '合計金額',
+  'クーポンコード',
+] as const
+
+const parseDate = (s: string | null): Date | undefined => {
+  if (!s) return undefined
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? undefined : d
+}
+
+export const GET = async (req: NextRequest) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error }, { status: check.status })
+  }
+
+  const from = parseDate(req.nextUrl.searchParams.get('from'))
+  const to = parseDate(req.nextUrl.searchParams.get('to'))
+
+  // 期間フィルター（指定があれば適用）
+  const where = {
+    ...(from || to
+      ? {
+          createdAt: {
+            ...(from ? { gte: from } : {}),
+            ...(to ? { lte: to } : {}),
+          },
+        }
+      : {}),
+  }
+
+  const orders = await prisma.order.findMany({
+    where,
+    include: {
+      user: { select: { id: true, email: true, name: true } },
+      items: { include: { product: { select: { id: true, name: true } } } },
+      coupon: { select: { code: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  // 注文明細を1行=1アイテムで展開する
+  const rows: unknown[][] = []
+  for (const order of orders) {
+    if (order.items.length === 0) {
+      rows.push([
+        order.id,
+        order.createdAt.toISOString(),
+        order.user.id,
+        order.user.email,
+        order.user.name ?? '',
+        order.status,
+        '',
+        '',
+        '',
+        '',
+        '',
+        order.totalPrice,
+        order.coupon?.code ?? '',
+      ])
+      continue
+    }
+    for (const item of order.items) {
+      rows.push([
+        order.id,
+        order.createdAt.toISOString(),
+        order.user.id,
+        order.user.email,
+        order.user.name ?? '',
+        order.status,
+        item.product.id,
+        item.product.name,
+        item.unitPrice,
+        item.quantity,
+        item.unitPrice * item.quantity,
+        order.totalPrice,
+        order.coupon?.code ?? '',
+      ])
+    }
+  }
+
+  const buf = toCsvWithBom(ORDER_CSV_HEADERS, rows)
+  const filename = `orders_${new Date().toISOString().slice(0, 10)}.csv`
+
+  return new NextResponse(buf as unknown as BodyInit, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/src/app/api/admin/export/sales/route.ts
+++ b/src/app/api/admin/export/sales/route.ts
@@ -1,0 +1,79 @@
+// 追加: 管理画面 売上サマリ CSV エクスポート API
+// GET /api/admin/export/sales?from=YYYY-MM-DD&to=YYYY-MM-DD&granularity=daily|monthly
+// 管理者ロール必須。CANCELLED を除く注文を集計する。
+import 'server-only'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db/prisma'
+import { requireAdmin } from '@/lib/admin-auth'
+import { toCsvWithBom } from '@/lib/csv'
+
+const parseDate = (s: string | null): Date | undefined => {
+  if (!s) return undefined
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? undefined : d
+}
+
+// 日次/月次のキー（YYYY-MM-DD or YYYY-MM）を生成
+const formatKey = (d: Date, granularity: 'daily' | 'monthly'): string => {
+  const iso = d.toISOString()
+  return granularity === 'monthly' ? iso.slice(0, 7) : iso.slice(0, 10)
+}
+
+export const GET = async (req: NextRequest) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error }, { status: check.status })
+  }
+
+  const from = parseDate(req.nextUrl.searchParams.get('from'))
+  const to = parseDate(req.nextUrl.searchParams.get('to'))
+  const granularityRaw = req.nextUrl.searchParams.get('granularity')
+  const granularity: 'daily' | 'monthly' = granularityRaw === 'monthly' ? 'monthly' : 'daily'
+
+  const orders = await prisma.order.findMany({
+    where: {
+      status: { not: 'CANCELLED' },
+      ...(from || to
+        ? {
+            createdAt: {
+              ...(from ? { gte: from } : {}),
+              ...(to ? { lte: to } : {}),
+            },
+          }
+        : {}),
+    },
+    select: { createdAt: true, totalPrice: true },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  // 期間ごとに集計
+  const aggregated = new Map<string, { count: number; total: number }>()
+  for (const o of orders) {
+    const key = formatKey(o.createdAt, granularity)
+    const cur = aggregated.get(key) ?? { count: 0, total: 0 }
+    cur.count += 1
+    cur.total += o.totalPrice
+    aggregated.set(key, cur)
+  }
+
+  const headers =
+    granularity === 'monthly'
+      ? (['月', '注文数', '売上合計（円）'] as const)
+      : (['日付', '注文数', '売上合計（円）'] as const)
+
+  const rows = Array.from(aggregated.entries())
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .map(([key, v]) => [key, v.count, v.total])
+
+  const buf = toCsvWithBom(headers, rows)
+  const filename = `sales_${granularity}_${new Date().toISOString().slice(0, 10)}.csv`
+
+  return new NextResponse(buf as unknown as BodyInit, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -1,0 +1,35 @@
+// 追加: csv ユーティリティの単体テスト
+import { describe, it, expect } from 'vitest'
+import { toCsv, toCsvWithBom } from './csv'
+
+describe('toCsv', () => {
+  it('ヘッダと行を CRLF で結合する', () => {
+    const csv = toCsv(['id', 'name'], [['1', 'foo']])
+    expect(csv).toBe('id,name\r\n1,foo')
+  })
+
+  it('カンマ・改行・ダブルクォートを含む値はエスケープされる', () => {
+    const csv = toCsv(['a'], [['x,y'], ['z\n"q"']])
+    expect(csv).toBe('a\r\n"x,y"\r\n"z\n""q"""')
+  })
+
+  it('null / undefined は空文字に変換される', () => {
+    const csv = toCsv(['a', 'b'], [[null, undefined]])
+    expect(csv).toBe('a,b\r\n,')
+  })
+
+  it('数値は文字列化される', () => {
+    const csv = toCsv(['n'], [[1234]])
+    expect(csv).toBe('n\r\n1234')
+  })
+})
+
+describe('toCsvWithBom', () => {
+  it('UTF-8 BOM を先頭に付与する', () => {
+    const buf = toCsvWithBom(['a'], [['日本語']])
+    expect(buf[0]).toBe(0xef)
+    expect(buf[1]).toBe(0xbb)
+    expect(buf[2]).toBe(0xbf)
+    expect(buf.subarray(3).toString('utf-8')).toBe('a\r\n日本語')
+  })
+})

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,26 @@
+// 追加: CSV エンコードユーティリティ
+// Excel / Google Sheets で文字化けせずに開けるよう UTF-8 BOM を付与する。
+// 値内のダブルクォート・カンマ・改行は RFC 4180 に従いエスケープする。
+
+const escapeCell = (value: unknown): string => {
+  if (value === null || value === undefined) return ''
+  const s = typeof value === 'string' ? value : String(value)
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+export const toCsv = (headers: readonly string[], rows: readonly (readonly unknown[])[]): string => {
+  const lines = [headers.map(escapeCell).join(',')]
+  for (const row of rows) {
+    lines.push(row.map(escapeCell).join(','))
+  }
+  return lines.join('\r\n')
+}
+
+// UTF-8 BOM 付き Buffer として返す（Excel 互換）
+export const toCsvWithBom = (headers: readonly string[], rows: readonly (readonly unknown[])[]): Buffer => {
+  const csv = toCsv(headers, rows)
+  return Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(csv, 'utf-8')])
+}


### PR DESCRIPTION
## 概要
Issue #74 対応。経理・分析用途で注文と売上を CSV ダウンロードできる管理者向け機能。

## 変更点
- `src/lib/csv.ts`: CSV エンコードユーティリティ
  - RFC 4180 準拠 (カンマ・改行・ダブルクォートをエスケープ)
  - UTF-8 BOM 付与で Excel/Google Sheets でも文字化け無し
  - 単体テスト 5 件
- `/api/admin/export/orders`: 注文一覧 CSV
  - クエリ `from`/`to` で期間フィルター
  - 注文明細を1行=1アイテムで展開
- `/api/admin/export/sales`: 売上サマリ CSV
  - `granularity=daily|monthly` で粒度切替
  - CANCELLED の注文は除外
- 管理画面: 注文一覧とダッシュボードに CSV ダウンロードボタン追加
- 全エンドポイントで `requireAdmin()` による管理者ロールチェック

Closes #74