### PR TITLE
feat(wishlist): クライアントキャッシュ用 Zustand ストアを追加 (#92)

### DIFF
--- a/src/stores/wishlistStore.test.ts
+++ b/src/stores/wishlistStore.test.ts
@@ -1,0 +1,80 @@
+// wishlistStore のユニットテスト
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useWishlistStore } from './wishlistStore'
+
+describe('useWishlistStore', () => {
+  beforeEach(() => {
+    // 各テスト前に状態をリセット
+    useWishlistStore.getState().clear()
+  })
+
+  it('初期状態は空である', () => {
+    const state = useWishlistStore.getState()
+    expect(state.count()).toBe(0)
+    expect(state.has('p1')).toBe(false)
+  })
+
+  it('setFromServer でサーバー状態を反映できる', () => {
+    useWishlistStore.getState().setFromServer(['p1', 'p2', 'p3'])
+    const state = useWishlistStore.getState()
+    expect(state.count()).toBe(3)
+    expect(state.has('p1')).toBe(true)
+    expect(state.has('p2')).toBe(true)
+    expect(state.has('x')).toBe(false)
+  })
+
+  it('add で楽観的に追加できる', () => {
+    useWishlistStore.getState().add('p1')
+    expect(useWishlistStore.getState().has('p1')).toBe(true)
+    expect(useWishlistStore.getState().count()).toBe(1)
+  })
+
+  it('add は重複しても件数が増えない（idempotent）', () => {
+    const store = useWishlistStore.getState()
+    store.add('p1')
+    store.add('p1')
+    store.add('p1')
+    expect(useWishlistStore.getState().count()).toBe(1)
+  })
+
+  it('remove で削除できる', () => {
+    const store = useWishlistStore.getState()
+    store.add('p1')
+    store.add('p2')
+    store.remove('p1')
+    expect(useWishlistStore.getState().has('p1')).toBe(false)
+    expect(useWishlistStore.getState().has('p2')).toBe(true)
+    expect(useWishlistStore.getState().count()).toBe(1)
+  })
+
+  it('存在しないIDの remove は安全に無視される', () => {
+    useWishlistStore.getState().remove('not-exist')
+    expect(useWishlistStore.getState().count()).toBe(0)
+  })
+
+  it('clear で全件削除される', () => {
+    const store = useWishlistStore.getState()
+    store.setFromServer(['p1', 'p2'])
+    store.clear()
+    expect(useWishlistStore.getState().count()).toBe(0)
+  })
+
+  it('setFromServer は既存状態を上書きする', () => {
+    const store = useWishlistStore.getState()
+    store.setFromServer(['a', 'b'])
+    store.setFromServer(['c'])
+    expect(useWishlistStore.getState().has('a')).toBe(false)
+    expect(useWishlistStore.getState().has('c')).toBe(true)
+    expect(useWishlistStore.getState().count()).toBe(1)
+  })
+
+  it('add → remove → add で状態が正しく遷移する', () => {
+    const store = useWishlistStore.getState()
+    store.add('p1')
+    expect(useWishlistStore.getState().has('p1')).toBe(true)
+    store.remove('p1')
+    expect(useWishlistStore.getState().has('p1')).toBe(false)
+    store.add('p1')
+    expect(useWishlistStore.getState().has('p1')).toBe(true)
+  })
+})

--- a/src/stores/wishlistStore.ts
+++ b/src/stores/wishlistStore.ts
@@ -1,0 +1,56 @@
+// ウィッシュリストの軽量クライアントキャッシュ（Zustand）
+// 既存実装はサーバー側状態 + router.refresh() を主軸とするが、
+// 商品一覧やヘッダーバッジでの即時反映用に productId セットだけをクライアントに持つ。
+import { create } from 'zustand'
+
+// 追加: ウィッシュリストストアの型
+type WishlistStore = {
+  // 追加: 現在ウィッシュリストに入っている productId の集合
+  productIds: Set<string>
+  // 追加: サーバーから取得した productId 配列で内部状態を上書き
+  setFromServer: (productIds: readonly string[]) => void
+  // 追加: 楽観的に追加
+  add: (productId: string) => void
+  // 追加: 楽観的に削除
+  remove: (productId: string) => void
+  // 追加: ウィッシュリスト判定
+  has: (productId: string) => boolean
+  // 追加: 件数取得
+  count: () => number
+  // 追加: クリア（ログアウト時など）
+  clear: () => void
+}
+
+export const useWishlistStore = create<WishlistStore>((set, get) => ({
+  productIds: new Set<string>(),
+
+  setFromServer: (productIds) => {
+    set({ productIds: new Set(productIds) })
+  },
+
+  add: (productId) => {
+    set((state) => {
+      if (state.productIds.has(productId)) return state
+      const next = new Set(state.productIds)
+      next.add(productId)
+      return { productIds: next }
+    })
+  },
+
+  remove: (productId) => {
+    set((state) => {
+      if (!state.productIds.has(productId)) return state
+      const next = new Set(state.productIds)
+      next.delete(productId)
+      return { productIds: next }
+    })
+  },
+
+  has: (productId) => get().productIds.has(productId),
+
+  count: () => get().productIds.size,
+
+  clear: () => {
+    set({ productIds: new Set<string>() })
+  },
+}))


### PR DESCRIPTION
## 概要
ウィッシュリストのクライアント側キャッシュ用に Zustand ストア `useWishlistStore` を追加します。
既存実装はサーバー状態 + `router.refresh()` を主軸としていますが、商品一覧やヘッダーバッジでの即時反映用途に productId 集合だけを保持できる軽量ストアを用意しました。

## 変更内容
- `src/stores/wishlistStore.ts` 新規追加
  - `productIds: Set<string>` を内部状態として保持
  - `setFromServer` / `add` / `remove` / `has` / `count` / `clear` API
  - 重複追加・存在しないIDの削除に対して idempotent
- `src/stores/wishlistStore.test.ts` ユニットテスト 9 件追加

## テスト
- `pnpm vitest run src/stores/wishlistStore.test.ts` → 9/9 pass
- `pnpm lint` / `npx tsc --noEmit` パス

Closes #92