### PR TITLE
feat(logger): 構造化ロガー lib/logger を追加 (#97)

### DIFF
--- a/src/app/api/coupons/validate/route.ts
+++ b/src/app/api/coupons/validate/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { findCouponByCode } from '@/lib/db/coupons'
 import { couponCodeSchema } from '@/lib/validators/coupon'
+import { logger } from '@/lib/logger' // 追加
 
 // POST /api/coupons/validate - クーポンコードの有効性を検証し割引率を返す
 export const POST = async (req: NextRequest) => {
@@ -44,7 +45,7 @@ export const POST = async (req: NextRequest) => {
       discountPct: coupon.discountPct,
     })
   } catch (err) {
-    console.error('[coupons/validate POST] エラー:', err)
+    logger.error('[coupons/validate POST] エラー', { err }) // 変更
     return NextResponse.json({ error: 'クーポンの確認に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
   }
 }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -8,6 +8,7 @@ import type { Prisma } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
 import { sendOrderConfirmationEmail } from '@/lib/email/sendOrderConfirmation' // 追加
 import { enforceRateLimit } from '@/lib/rateLimit'
+import { logger } from '@/lib/logger' // 追加
 
 type CartItemInput = {
   id: string
@@ -32,7 +33,7 @@ export const GET = async () => {
     const orders = await findOrdersByUserId(session.user.id)
     return NextResponse.json({ orders })
   } catch (err) {
-    console.error('[orders GET] エラー:', err)
+    logger.error('[orders GET] エラー', { err }) // 変更
     return NextResponse.json({ error: '注文一覧の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
   }
 }
@@ -147,7 +148,7 @@ export const POST = async (req: NextRequest) => {
     return NextResponse.json({ orderId: order.id }, { status: 201 })
   } catch (err) {
     const message = err instanceof Error ? err.message : '不明なエラー'
-    console.error('[orders POST] エラー:', err)
+    logger.error('[orders POST] エラー', { err }) // 変更
     return NextResponse.json({ error: message, code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
   }
 }

--- a/src/app/api/reviews/[productId]/route.ts
+++ b/src/app/api/reviews/[productId]/route.ts
@@ -8,6 +8,7 @@ import {
   findPublicReviewsByProductId,
   findReviewByUserAndProduct,
 } from '@/lib/db/reviews'
+import { logger } from '@/lib/logger' // 追加
 
 // レビュー投稿スキーマ
 const reviewSchema = z.object({
@@ -32,7 +33,7 @@ export const GET = async (
     ])
     return NextResponse.json({ reviews, total })
   } catch (err) {
-    console.error('[reviews GET] エラー:', err)
+    logger.error('[reviews GET] エラー', { err }) // 変更
     return NextResponse.json(
       { error: 'レビューの取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },
@@ -96,7 +97,7 @@ export const POST = async (
         { status: 409 },
       )
     }
-    console.error('[reviews POST] エラー:', err)
+    logger.error('[reviews POST] エラー', { err }) // 変更
     return NextResponse.json(
       { error: 'レビューの投稿に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },

--- a/src/app/api/stripe/payment-intent/route.ts
+++ b/src/app/api/stripe/payment-intent/route.ts
@@ -5,6 +5,7 @@ import { validateCartItems } from '@/lib/db/products'
 import { findCouponByCode } from '@/lib/db/coupons' // 追加
 import { stripe } from '@/lib/stripe'
 import { enforceRateLimit } from '@/lib/rateLimit'
+import { logger } from '@/lib/logger' // 追加
 
 type CartItemInput = {
   id: string
@@ -80,7 +81,7 @@ export const POST = async (req: NextRequest) => {
     })
   } catch (err) {
     const message = err instanceof Error ? err.message : '不明なエラー'
-    console.error('[stripe/payment-intent POST] エラー:', err)
+    logger.error('[stripe/payment-intent POST] エラー', { err }) // 変更
     return NextResponse.json({ error: message, code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
   }
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -5,6 +5,7 @@ import type Stripe from 'stripe'
 import { env } from '@/env'
 import { updateOrderToPaidByStripeId } from '@/lib/db/orders'
 import { stripe } from '@/lib/stripe'
+import { logger } from '@/lib/logger' // 追加
 
 // Next.js App Router では生の body 読み取りのため bodyParser を無効化
 export const dynamic = 'force-dynamic'
@@ -23,7 +24,7 @@ export const POST = async (req: NextRequest) => {
   try {
     event = stripe.webhooks.constructEvent(body, sig, env.STRIPE_WEBHOOK_SECRET)
   } catch (err) {
-    console.error('[stripe/webhook] 署名検証失敗:', err)
+    logger.error('[stripe/webhook] 署名検証失敗', { err }) // 変更
     return NextResponse.json({ error: 'Webhook 署名の検証に失敗しました' }, { status: 400 })
   }
 
@@ -43,7 +44,7 @@ export const POST = async (req: NextRequest) => {
         break
     }
   } catch (err) {
-    console.error('[stripe/webhook] イベント処理エラー:', err)
+    logger.error('[stripe/webhook] イベント処理エラー', { err }) // 変更
     return NextResponse.json({ error: 'イベント処理に失敗しました' }, { status: 500 })
   }
 

--- a/src/app/api/wishlist/[productId]/route.ts
+++ b/src/app/api/wishlist/[productId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { removeProductFromWishlist, isProductInWishlist } from '@/lib/db/wishlist'
+import { logger } from '@/lib/logger' // 追加
 
 // DELETE /api/wishlist/[productId] - ウィッシュリストから商品削除（要認証）
 export const DELETE = async (
@@ -31,7 +32,7 @@ export const DELETE = async (
     await removeProductFromWishlist(userId, productId)
     return NextResponse.json({ success: true })
   } catch (err) {
-    console.error('[wishlist DELETE] エラー:', err)
+    logger.error('[wishlist DELETE] エラー', { err }) // 変更
     return NextResponse.json(
       { error: 'ウィッシュリストからの削除に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },

--- a/src/app/api/wishlist/route.ts
+++ b/src/app/api/wishlist/route.ts
@@ -7,6 +7,7 @@ import {
   findWishlistByUserId,
   isProductInWishlist,
 } from '@/lib/db/wishlist'
+import { logger } from '@/lib/logger' // 追加
 
 // POST /api/wishlist リクエストスキーマ
 const addWishlistSchema = z.object({
@@ -28,7 +29,7 @@ export const GET = async () => {
     const items = wishlist?.items ?? []
     return NextResponse.json({ items })
   } catch (err) {
-    console.error('[wishlist GET] エラー:', err)
+    logger.error('[wishlist GET] エラー', { err }) // 変更
     return NextResponse.json(
       { error: 'ウィッシュリストの取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },
@@ -92,7 +93,7 @@ export const POST = async (req: NextRequest) => {
     await addProductToWishlist(userId, productId)
     return NextResponse.json({ success: true }, { status: 201 })
   } catch (err) {
-    console.error('[wishlist POST] エラー:', err)
+    logger.error('[wishlist POST] エラー', { err }) // 変更
     return NextResponse.json(
       { error: 'ウィッシュリストへの追加に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
       { status: 500 },

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,67 @@
+// logger のユニットテスト
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __internal, logger } from './logger'
+
+describe('logger', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    // 開発時の console フォールバック対策
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('error は stderr または console.error に出力される', () => {
+    logger.error('test error', { code: 'X' })
+    const wrote =
+      stderrSpy.mock.calls.length > 0 || errorSpy.mock.calls.length > 0
+    expect(wrote).toBe(true)
+  })
+
+  it('テスト環境では debug/info/warn は出力を抑制される', () => {
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    expect(stdoutSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it('normalize は Error を name/message/stack に展開する', () => {
+    const e = new Error('boom')
+    const out = __internal.normalize(e)
+    expect(out).toMatchObject({ name: 'Error', message: 'boom' })
+    expect(typeof (out as { stack: unknown }).stack).toBe('string')
+  })
+
+  it('normalize はプリミティブをそのまま返す', () => {
+    expect(__internal.normalize('x')).toBe('x')
+    expect(__internal.normalize(1)).toBe(1)
+    expect(__internal.normalize(null)).toBe(null)
+  })
+
+  it('normalizeContext は undefined を返す（入力なし）', () => {
+    expect(__internal.normalizeContext(undefined)).toBeUndefined()
+  })
+
+  it('normalizeContext は Error 値を展開する', () => {
+    const out = __internal.normalizeContext({ err: new Error('x'), id: '1' })
+    expect(out?.err).toMatchObject({ message: 'x' })
+    expect(out?.id).toBe('1')
+  })
+
+  it('shouldLog はテスト環境で error のみ通す', () => {
+    expect(__internal.shouldLog('debug')).toBe(false)
+    expect(__internal.shouldLog('info')).toBe(false)
+    expect(__internal.shouldLog('warn')).toBe(false)
+    expect(__internal.shouldLog('error')).toBe(true)
+  })
+})

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,101 @@
+// 構造化ロガー
+// 本番では JSON 1行 / 開発では人間向け整形出力。Sentry とは独立し、
+// アプリケーションログ（API・DB アクセス・バックグラウンド処理）の標準出力を一元化する。
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+// 環境による最小ログレベル（数値が大きいほど深刻）
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+}
+
+const isProd = process.env.NODE_ENV === 'production'
+const isTest = process.env.NODE_ENV === 'test'
+
+// テスト環境ではログを抑制（NOISE 削減）。本番は info 以上、開発は debug 以上。
+const minLevel: LogLevel = isTest ? 'error' : isProd ? 'info' : 'debug'
+
+// 任意の値を JSON シリアライズ可能な形へ正規化（Error 等の特殊値を扱う）
+const normalize = (value: unknown): unknown => {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    }
+  }
+  return value
+}
+
+const normalizeContext = (ctx?: Record<string, unknown>): Record<string, unknown> | undefined => {
+  if (!ctx) return undefined
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(ctx)) {
+    out[k] = normalize(v)
+  }
+  return out
+}
+
+const shouldLog = (level: LogLevel): boolean => {
+  return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[minLevel]
+}
+
+const writeLog = (level: LogLevel, message: string, context?: Record<string, unknown>) => {
+  if (!shouldLog(level)) return
+
+  const ctx = normalizeContext(context)
+  const payload = {
+    level,
+    time: new Date().toISOString(),
+    message,
+    ...(ctx ?? {}),
+  }
+
+  // 出力先: error/warn は stderr、それ以外は stdout
+  const target: 'stderr' | 'stdout' = level === 'error' || level === 'warn' ? 'stderr' : 'stdout'
+
+  if (isProd) {
+    // 本番は JSON 1行（CloudWatch / Vercel Logs / 任意の集約基盤で構造化検索可能）
+    const line = JSON.stringify(payload)
+    if (target === 'stderr') {
+      process.stderr.write(line + '\n')
+    } else {
+      process.stdout.write(line + '\n')
+    }
+    return
+  }
+
+  // 開発・テストは人間が読みやすい形（context があれば末尾に JSON 整形）
+  const prefix = `[${payload.time}] ${level.toUpperCase()} ${message}`
+  if (target === 'stderr') {
+    if (ctx && Object.keys(ctx).length > 0) {
+      // eslint-disable-next-line no-console
+      console.error(prefix, ctx)
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(prefix)
+    }
+  } else {
+    if (ctx && Object.keys(ctx).length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(prefix, ctx)
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(prefix)
+    }
+  }
+}
+
+// アプリケーション全体で使うロガーインターフェース
+export const logger = {
+  debug: (message: string, context?: Record<string, unknown>) => writeLog('debug', message, context),
+  info: (message: string, context?: Record<string, unknown>) => writeLog('info', message, context),
+  warn: (message: string, context?: Record<string, unknown>) => writeLog('warn', message, context),
+  error: (message: string, context?: Record<string, unknown>) => writeLog('error', message, context),
+}
+
+// テスト用にエクスポート（内部ユーティリティ）
+export const __internal = { normalize, normalizeContext, shouldLog, minLevel }


### PR DESCRIPTION
## 概要
本番環境では JSON 1行、開発環境では人間向けの整形出力を行う構造化ロガー `src/lib/logger.ts` を追加します。Sentry とは独立して、API・DB アクセス・バックグラウンド処理の標準出力を一元化します。

## 変更内容
- `src/lib/logger.ts` 新規追加
  - `debug` / `info` / `warn` / `error` の4レベル
  - 本番: JSON、開発: 整形ログ、テスト: error 以上のみ
  - `Error` を name/message/stack に正規化
  - error/warn は stderr、それ以外は stdout
- `src/lib/logger.test.ts` ユニットテスト 7 件
- 主要 API ルートの `console.error` を `logger.error` に置き換え:
  - `api/wishlist` (POST/GET/DELETE)
  - `api/orders` (POST/GET)
  - `api/stripe/payment-intent`
  - `api/stripe/webhook` (署名検証/イベント処理)
  - `api/coupons/validate`
  - `api/reviews/[productId]` (POST/GET)

外部依存（pino 等）は追加せず、ゼロ依存の軽量実装としています。

## テスト
- `pnpm vitest run` → 88/88 pass
- `npx tsc --noEmit` クリーン

Closes #97