### PR TITLE
feat(product): 関連商品レコメンド + 最近見た商品 (#103)

### DIFF
--- a/src/app/(shop)/products/[id]/page.tsx
+++ b/src/app/(shop)/products/[id]/page.tsx
@@ -9,6 +9,8 @@ import { findReviewByUserAndProduct } from '@/lib/db/reviews'
 import { getReviewStatsByProductId } from '@/lib/db/reviews' // 追加: aggregateRating用
 import { isProductInWishlist } from '@/lib/db/wishlist' // 追加
 import { ProductDetail } from '@/components/features/product/ProductDetail'
+import { RelatedProducts } from '@/components/features/product/RelatedProducts' // 追加 (#103)
+import { RecentlyViewedProducts } from '@/components/features/product/RecentlyViewedProducts' // 追加 (#103)
 import { ReviewForm } from '@/components/features/review/ReviewForm'
 import { ReviewList } from '@/components/features/review/ReviewList'
 import { env } from '@/env' // 追加: 構造化データ用URL生成
@@ -155,6 +157,19 @@ export default async function ProductDetailPage({ params }: Props) {
           productId={product.id}
           isLoggedIn={!!userId}
           hasReviewed={hasReviewed}
+        />
+        {/* 追加 (#103): 関連商品（同カテゴリ） */}
+        <Suspense fallback={null}>
+          <RelatedProducts categoryId={product.categoryId} excludeId={product.id} />
+        </Suspense>
+        {/* 追加 (#103): 最近見た商品（クライアント側） */}
+        <RecentlyViewedProducts
+          currentProduct={{
+            id: product.id,
+            name: product.name,
+            price: product.price,
+            imageUrl: product.images[0] ?? null,
+          }}
         />
       </div>
     </div>

--- a/src/components/features/product/RecentlyViewedProducts.tsx
+++ b/src/components/features/product/RecentlyViewedProducts.tsx
@@ -1,0 +1,66 @@
+// 追加 (#103): 最近見た商品セクション（Client Component）
+// localStorage から履歴を読み出して表示する。現在の商品は除外する。
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { useRecentlyViewedStore, type RecentlyViewedItem } from '@/stores/recentlyViewedStore'
+
+type Props = {
+  // 現在表示している商品。表示時点で履歴に追加する。
+  currentProduct: RecentlyViewedItem
+}
+
+export const RecentlyViewedProducts = ({ currentProduct }: Props) => {
+  const items = useRecentlyViewedStore((s) => s.items)
+  const add = useRecentlyViewedStore((s) => s.add)
+
+  // 詳細ページを開いたタイミングで履歴に積む
+  useEffect(() => {
+    add(currentProduct)
+  }, [add, currentProduct])
+
+  // 現在の商品は除外
+  const filtered = items.filter((i) => i.id !== currentProduct.id)
+  if (filtered.length === 0) return null
+
+  return (
+    <section aria-labelledby="recently-viewed-heading" className="space-y-4">
+      <h2 id="recently-viewed-heading" className="text-xl font-bold">
+        最近見た商品
+      </h2>
+      <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+        {filtered.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={`/products/${item.id}`}
+              className="group block overflow-hidden rounded-lg border border-gray-200 bg-white transition-shadow hover:shadow-md"
+              aria-label={`${item.name}の詳細を見る`}
+            >
+              <div className="relative aspect-square w-full overflow-hidden bg-gray-100">
+                {item.imageUrl ? (
+                  <Image
+                    src={item.imageUrl}
+                    alt={item.name}
+                    fill
+                    sizes="(max-width: 640px) 50vw, 20vw"
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-gray-400">
+                    <span className="text-xs">画像なし</span>
+                  </div>
+                )}
+              </div>
+              <div className="p-2">
+                <p className="line-clamp-2 text-sm">{item.name}</p>
+                <p className="mt-1 text-sm font-bold">¥{item.price.toLocaleString()}</p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/features/product/RelatedProducts.tsx
+++ b/src/components/features/product/RelatedProducts.tsx
@@ -1,0 +1,38 @@
+// 追加 (#103): 関連商品セクション（Server Component）
+// 同カテゴリの商品を最大8件表示する
+import { findRelatedProducts } from '@/lib/db/products'
+import { ProductCard } from '@/components/features/product/ProductCard'
+import { RELATED_PRODUCTS_LIMIT } from '@/constants/recommend'
+
+type Props = {
+  categoryId: string | null
+  excludeId: string
+}
+
+export const RelatedProducts = async ({ categoryId, excludeId }: Props) => {
+  // カテゴリ未設定の商品は関連商品を表示しない
+  if (!categoryId) return null
+
+  const related = await findRelatedProducts({
+    categoryId,
+    excludeId,
+    limit: RELATED_PRODUCTS_LIMIT,
+  })
+
+  if (related.length === 0) return null
+
+  return (
+    <section aria-labelledby="related-products-heading" className="space-y-4">
+      <h2 id="related-products-heading" className="text-xl font-bold">
+        関連商品
+      </h2>
+      <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {related.map((product) => (
+          <li key={product.id}>
+            <ProductCard product={product} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/constants/recommend.ts
+++ b/src/constants/recommend.ts
@@ -1,0 +1,4 @@
+// 追加 (#103): レコメンド機能の定数
+export const RELATED_PRODUCTS_LIMIT = 8
+export const RECENTLY_VIEWED_LIMIT = 10
+export const RECENTLY_VIEWED_STORAGE_KEY = 'recently-viewed-products-v1'

--- a/src/lib/db/products.ts
+++ b/src/lib/db/products.ts
@@ -95,6 +95,25 @@ export const findProductByIdForAdmin = async (id: string) => {
   })
 }
 
+// 追加 (#103): 関連商品取得（同カテゴリ・公開済み・指定商品を除外）
+export const findRelatedProducts = async (params: {
+  categoryId: string
+  excludeId: string
+  limit?: number
+}) => {
+  const { categoryId, excludeId, limit = 8 } = params
+  return prisma.product.findMany({
+    where: {
+      isPublished: true,
+      categoryId,
+      id: { not: excludeId },
+    },
+    include: { category: true },
+    take: limit,
+    orderBy: { createdAt: 'desc' },
+  })
+}
+
 type CartItemInput = {
   id: string
   quantity: number

--- a/src/stores/recentlyViewedStore.test.ts
+++ b/src/stores/recentlyViewedStore.test.ts
@@ -1,0 +1,53 @@
+// 追加 (#103): recentlyViewedStore のユニットテスト
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useRecentlyViewedStore, type RecentlyViewedItem } from './recentlyViewedStore'
+
+const item = (id: string): RecentlyViewedItem => ({
+  id,
+  name: `商品${id}`,
+  price: 100,
+  imageUrl: null,
+})
+
+describe('useRecentlyViewedStore', () => {
+  beforeEach(() => {
+    useRecentlyViewedStore.getState().clear()
+  })
+
+  it('初期状態は空である', () => {
+    expect(useRecentlyViewedStore.getState().items).toEqual([])
+  })
+
+  it('add で先頭に積まれる', () => {
+    const { add } = useRecentlyViewedStore.getState()
+    add(item('a'))
+    add(item('b'))
+    expect(useRecentlyViewedStore.getState().items.map((i) => i.id)).toEqual(['b', 'a'])
+  })
+
+  it('同一IDは重複せず先頭に詰め直される', () => {
+    const { add } = useRecentlyViewedStore.getState()
+    add(item('a'))
+    add(item('b'))
+    add(item('a'))
+    expect(useRecentlyViewedStore.getState().items.map((i) => i.id)).toEqual(['a', 'b'])
+  })
+
+  it('上限（10件）を超える分は古いものから捨てられる', () => {
+    const { add } = useRecentlyViewedStore.getState()
+    for (let i = 0; i < 12; i++) {
+      add(item(`p${i}`))
+    }
+    const ids = useRecentlyViewedStore.getState().items.map((i) => i.id)
+    expect(ids.length).toBe(10)
+    expect(ids[0]).toBe('p11')
+    expect(ids[ids.length - 1]).toBe('p2')
+  })
+
+  it('clear で全件削除される', () => {
+    const { add, clear } = useRecentlyViewedStore.getState()
+    add(item('a'))
+    clear()
+    expect(useRecentlyViewedStore.getState().items).toEqual([])
+  })
+})

--- a/src/stores/recentlyViewedStore.ts
+++ b/src/stores/recentlyViewedStore.ts
@@ -1,0 +1,37 @@
+// 追加 (#103): 最近見た商品ストア（Zustand + localStorage 永続化）
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { RECENTLY_VIEWED_LIMIT, RECENTLY_VIEWED_STORAGE_KEY } from '@/constants/recommend'
+
+// 履歴に保存する最低限の情報のみを持つ
+export type RecentlyViewedItem = {
+  id: string
+  name: string
+  price: number
+  imageUrl: string | null
+}
+
+type RecentlyViewedStore = {
+  items: RecentlyViewedItem[]
+  add: (item: RecentlyViewedItem) => void
+  clear: () => void
+}
+
+export const useRecentlyViewedStore = create<RecentlyViewedStore>()(
+  persist(
+    (set) => ({
+      items: [],
+
+      // 同一IDがあれば先頭に詰め直し、上限を超えた古い履歴は捨てる
+      add: (item) => {
+        set((state) => {
+          const filtered = state.items.filter((i) => i.id !== item.id)
+          return { items: [item, ...filtered].slice(0, RECENTLY_VIEWED_LIMIT) }
+        })
+      },
+
+      clear: () => set({ items: [] }),
+    }),
+    { name: RECENTLY_VIEWED_STORAGE_KEY },
+  ),
+)


### PR DESCRIPTION
Closes #103

## 変更内容
- `src/lib/db/products.ts` に `findRelatedProducts` を追加（同カテゴリ・公開商品・自身を除外）
- `RelatedProducts` (Server Component): 同カテゴリ商品を最大 8 件
- `useRecentlyViewedStore` (Zustand + localStorage 永続化): 最大 10 件、同一ID 重複なし
- `RecentlyViewedProducts` (Client Component): 詳細ページ表示時に履歴へ追加し、現在商品を除外して表示
- 商品詳細ページに両セクションを追加

## 受け入れ条件
- [x] findRelatedProducts を追加
- [x] 関連商品セクション（最大 8 件・同カテゴリ）
- [x] 最近見た商品セクション（最大 10 件・現在商品を除外）
- [x] ユニットテスト（recentlyViewedStore）
- [ ] E2E テストは別途追加（既存 e2e/purchase-flow に影響しないため今回は対象外）