### PR TITLE
feat(product): 検索強化（サジェスト/価格レンジ/在庫トグル/人気順）(#104)

### DIFF
--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -22,7 +22,7 @@ export default function CartPage() {
     return (
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <h1 className="mb-8 text-2xl font-bold tracking-tight">カート</h1>
-        <div className="animate-pulse space-y-4" aria-label="読み込み中">
+        <div className="animate-pulse space-y-4" role="status" aria-label="読み込み中">
           <div className="h-24 rounded-lg bg-muted" />
           <div className="h-24 rounded-lg bg-muted" />
         </div>

--- a/src/app/(shop)/products/page.tsx
+++ b/src/app/(shop)/products/page.tsx
@@ -10,6 +10,9 @@ import { ProductList } from '@/components/features/product/ProductList'
 import { ProductSearch } from '@/components/features/product/ProductSearch'
 import { ProductSort } from '@/components/features/product/ProductSort'
 import { ProductFilter } from '@/components/features/product/ProductFilter'
+import { ProductPriceFilter } from '@/components/features/product/ProductPriceFilter' // 追加 (#104)
+import { ProductStockFilter } from '@/components/features/product/ProductStockFilter' // 追加 (#104)
+import { PRICE_RANGE_MAX } from '@/constants/search' // 追加 (#104)
 
 export const metadata: Metadata = {
   title: '商品一覧',
@@ -23,6 +26,10 @@ type SearchParams = {
   search?: SearchParamValue
   categoryId?: SearchParamValue
   sort?: SearchParamValue
+  // 追加 (#104)
+  minPrice?: SearchParamValue
+  maxPrice?: SearchParamValue
+  inStockOnly?: SearchParamValue
 }
 
 type Props = {
@@ -40,6 +47,16 @@ const SORT_ORDER_MAP: Record<string, Prisma.ProductOrderByWithRelationInput> = {
   newest: { createdAt: 'desc' },
   price_asc: { price: 'asc' },
   price_desc: { price: 'desc' },
+  // 追加 (#104): 注文された数（OrderItem 件数）の多い順
+  popular: { orderItems: { _count: 'desc' } },
+}
+
+// 追加 (#104): 価格パラメータの数値変換ヘルパー（範囲外は無視）
+const parsePrice = (value: string | undefined): number | undefined => {
+  if (!value) return undefined
+  const n = Number(value)
+  if (!Number.isFinite(n) || n < 0 || n > PRICE_RANGE_MAX) return undefined
+  return Math.floor(n)
 }
 
 export default async function ProductsPage({ searchParams }: Props) {
@@ -50,6 +67,10 @@ export default async function ProductsPage({ searchParams }: Props) {
   const categoryId = resolveParam(sp.categoryId)
   const sort = resolveParam(sp.sort) ?? 'newest'
   const orderBy = SORT_ORDER_MAP[sort] ?? { createdAt: 'desc' }
+  // 追加 (#104): 価格レンジ・在庫フィルター
+  const minPrice = parsePrice(resolveParam(sp.minPrice))
+  const maxPrice = parsePrice(resolveParam(sp.maxPrice))
+  const inStockOnly = resolveParam(sp.inStockOnly) === '1'
 
   // 追加: セッション取得（ウィッシュリスト状態取得のため）
   const session = await auth()
@@ -57,7 +78,7 @@ export default async function ProductsPage({ searchParams }: Props) {
 
   // カテゴリ一覧・プロダクト一覧・ウィッシュリスト状態を並行取得
   const [products, categories, wishlistedProductIds] = await Promise.all([
-    findProducts({ search, categoryId, orderBy }),
+    findProducts({ search, categoryId, orderBy, minPrice, maxPrice, inStockOnly }),
     findAllCategories(), // 変更: リポジトリ関数経由に変更
     userId ? findWishlistedProductIds(userId) : Promise.resolve(new Set<string>()), // 追加
   ])
@@ -77,6 +98,12 @@ export default async function ProductsPage({ searchParams }: Props) {
         <div className="flex flex-wrap items-center gap-3">
           <Suspense fallback={null}>
             <ProductFilter categories={categories} />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ProductPriceFilter />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ProductStockFilter />
           </Suspense>
           <Suspense fallback={null}>
             <ProductSort />

--- a/src/app/api/products/search-suggest/route.ts
+++ b/src/app/api/products/search-suggest/route.ts
@@ -1,0 +1,31 @@
+// 追加 (#104): 検索サジェスト Route Handler
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { findProductSuggestions } from '@/lib/db/products'
+import { enforceRateLimit } from '@/lib/rateLimit'
+import {
+  SEARCH_SUGGEST_LIMIT,
+  SEARCH_SUGGEST_MIN_QUERY_LENGTH,
+} from '@/constants/search'
+
+const querySchema = z.object({
+  q: z.string().min(SEARCH_SUGGEST_MIN_QUERY_LENGTH).max(100),
+})
+
+export const GET = async (req: Request) => {
+  // レート制限（軽量だが連打されやすいため）
+  const limited = enforceRateLimit('SEARCH_SUGGEST', req)
+  if (limited) return limited
+
+  const { searchParams } = new URL(req.url)
+  const parsed = querySchema.safeParse({ q: searchParams.get('q') ?? '' })
+  if (!parsed.success) {
+    return NextResponse.json({ suggestions: [] })
+  }
+
+  const suggestions = await findProductSuggestions({
+    query: parsed.data.q,
+    limit: SEARCH_SUGGEST_LIMIT,
+  })
+  return NextResponse.json({ suggestions })
+}

--- a/src/components/features/product/ProductPriceFilter.tsx
+++ b/src/components/features/product/ProductPriceFilter.tsx
@@ -1,0 +1,86 @@
+'use client'
+// 追加 (#104): 価格レンジ絞り込みフィルター（Client Component）
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { PRICE_RANGE_MAX } from '@/constants/search'
+
+export const ProductPriceFilter = () => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const [minPrice, setMinPrice] = useState(searchParams.get('minPrice') ?? '')
+  const [maxPrice, setMaxPrice] = useState(searchParams.get('maxPrice') ?? '')
+
+  useEffect(() => {
+    setMinPrice(searchParams.get('minPrice') ?? '')
+    setMaxPrice(searchParams.get('maxPrice') ?? '')
+  }, [searchParams])
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      const params = new URLSearchParams(searchParams.toString())
+      // 入力値をバリデーション（0 以上 PRICE_RANGE_MAX 以下）
+      const min = Number(minPrice)
+      const max = Number(maxPrice)
+      if (minPrice && Number.isFinite(min) && min >= 0 && min <= PRICE_RANGE_MAX) {
+        params.set('minPrice', String(Math.floor(min)))
+      } else {
+        params.delete('minPrice')
+      }
+      if (maxPrice && Number.isFinite(max) && max >= 0 && max <= PRICE_RANGE_MAX) {
+        params.set('maxPrice', String(Math.floor(max)))
+      } else {
+        params.delete('maxPrice')
+      }
+      params.delete('skip')
+      router.push(`${pathname}?${params.toString()}`)
+    },
+    [router, pathname, searchParams, minPrice, maxPrice],
+  )
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <label htmlFor="minPrice" className="text-sm text-gray-600">
+        価格：
+      </label>
+      <input
+        id="minPrice"
+        type="number"
+        inputMode="numeric"
+        min={0}
+        max={PRICE_RANGE_MAX}
+        value={minPrice}
+        onChange={(e) => setMinPrice(e.target.value)}
+        placeholder="下限"
+        className="w-24 rounded-md border border-gray-300 px-2 py-1.5 text-sm outline-none focus:border-gray-500 focus:ring-1 focus:ring-gray-500"
+        aria-label="最低価格"
+      />
+      <span aria-hidden="true" className="text-sm text-gray-500">
+        〜
+      </span>
+      <label htmlFor="maxPrice" className="sr-only">
+        最高価格
+      </label>
+      <input
+        id="maxPrice"
+        type="number"
+        inputMode="numeric"
+        min={0}
+        max={PRICE_RANGE_MAX}
+        value={maxPrice}
+        onChange={(e) => setMaxPrice(e.target.value)}
+        placeholder="上限"
+        className="w-24 rounded-md border border-gray-300 px-2 py-1.5 text-sm outline-none focus:border-gray-500 focus:ring-1 focus:ring-gray-500"
+        aria-label="最高価格"
+      />
+      <button
+        type="submit"
+        className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100"
+      >
+        適用
+      </button>
+    </form>
+  )
+}

--- a/src/components/features/product/ProductSearch.tsx
+++ b/src/components/features/product/ProductSearch.tsx
@@ -1,57 +1,143 @@
 'use client'
 // キーワード検索コンポーネント（Client Component）
+// 変更 (#104): 検索サジェスト（debounce 300ms）対応
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
-import { useCallback, useState, useEffect } from 'react' // 変更: controlled input用フックを追加
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { SEARCH_SUGGEST_DEBOUNCE_MS, SEARCH_SUGGEST_MIN_QUERY_LENGTH } from '@/constants/search'
+
+type Suggestion = { id: string; name: string }
 
 export const ProductSearch = () => {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  // 変更: controlled inputのローカル状態（URLと常に同期）
   const [inputValue, setInputValue] = useState(searchParams.get('search') ?? '')
+  // 追加 (#104): サジェスト関連状態
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
 
-  // 変更: 戻るボタン操作など、URLが外部から変化した場合に表示値を同期する
+  // URL 変化時に input 値を同期
   useEffect(() => {
     setInputValue(searchParams.get('search') ?? '')
   }, [searchParams])
 
-  const handleSubmit = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault()
+  // 追加 (#104): debounce 経由でサジェスト取得
+  useEffect(() => {
+    const trimmed = inputValue.trim()
+    if (trimmed.length < SEARCH_SUGGEST_MIN_QUERY_LENGTH) {
+      setSuggestions([])
+      return
+    }
+    const ctrl = new AbortController()
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/products/search-suggest?q=${encodeURIComponent(trimmed)}`,
+          { signal: ctrl.signal },
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as { suggestions: Suggestion[] }
+        setSuggestions(data.suggestions ?? [])
+      } catch {
+        // ネットワークエラー時はサジェストを空にしてフォーム送信に委ねる
+      }
+    }, SEARCH_SUGGEST_DEBOUNCE_MS)
+
+    return () => {
+      ctrl.abort()
+      clearTimeout(timer)
+    }
+  }, [inputValue])
+
+  // 追加 (#104): 外側クリックでドロップダウンを閉じる
+  useEffect(() => {
+    const handleOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [])
+
+  const submitSearch = useCallback(
+    (value: string) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (inputValue) {
-        params.set('search', inputValue)
+      if (value) {
+        params.set('search', value)
       } else {
         params.delete('search')
       }
-      params.delete('skip') // 検索時はページをリセット
+      params.delete('skip')
+      setIsOpen(false)
       router.push(`${pathname}?${params.toString()}`)
     },
-    [router, pathname, searchParams, inputValue],
+    [router, pathname, searchParams],
+  )
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      submitSearch(inputValue)
+    },
+    [submitSearch, inputValue],
   )
 
   return (
-    <form onSubmit={handleSubmit} role="search" className="flex w-full gap-2">
-      <label htmlFor="search" className="sr-only">
-        商品を検索
-      </label>
-      <input
-        id="search"
-        name="search"
-        type="search"
-        value={inputValue}  // 変更: controlled inputに変更してURLとの乖離を防ぐ
-        onChange={(e) => setInputValue(e.target.value)}
-        placeholder="商品を検索..."
-        className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500 focus:ring-1 focus:ring-gray-500"
-        aria-label="商品を検索"
-      />
-      <button
-        type="submit"
-        className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-      >
-        検索
-      </button>
-    </form>
+    <div ref={containerRef} className="relative w-full">
+      <form onSubmit={handleSubmit} role="search" className="flex w-full gap-2">
+        <label htmlFor="search" className="sr-only">
+          商品を検索
+        </label>
+        <input
+          id="search"
+          name="search"
+          type="search"
+          autoComplete="off"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+            setIsOpen(true)
+          }}
+          onFocus={() => setIsOpen(true)}
+          placeholder="商品を検索..."
+          className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500 focus:ring-1 focus:ring-gray-500"
+          aria-label="商品を検索"
+          aria-autocomplete="list"
+          aria-expanded={isOpen && suggestions.length > 0}
+          aria-controls="search-suggestions"
+        />
+        <button
+          type="submit"
+          className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+        >
+          検索
+        </button>
+      </form>
+
+      {/* 追加 (#104): サジェストドロップダウン */}
+      {isOpen && suggestions.length > 0 && (
+        <ul
+          id="search-suggestions"
+          role="listbox"
+          className="absolute z-10 mt-1 max-h-72 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg"
+        >
+          {suggestions.map((s) => (
+            <li key={s.id} role="option" aria-selected="false">
+              <button
+                type="button"
+                onClick={() => {
+                  setInputValue(s.name)
+                  submitSearch(s.name)
+                }}
+                className="block w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-gray-100"
+              >
+                {s.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/src/components/features/product/ProductSearch.tsx
+++ b/src/components/features/product/ProductSearch.tsx
@@ -103,9 +103,6 @@ export const ProductSearch = () => {
           placeholder="商品を検索..."
           className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500 focus:ring-1 focus:ring-gray-500"
           aria-label="商品を検索"
-          aria-autocomplete="list"
-          aria-expanded={isOpen && suggestions.length > 0}
-          aria-controls="search-suggestions"
         />
         <button
           type="submit"

--- a/src/components/features/product/ProductSort.tsx
+++ b/src/components/features/product/ProductSort.tsx
@@ -7,6 +7,7 @@ const SORT_OPTIONS = [
   { value: 'newest', label: '新着順' },
   { value: 'price_asc', label: '価格が安い順' },
   { value: 'price_desc', label: '価格が高い順' },
+  { value: 'popular', label: '人気順' }, // 追加 (#104)
 ] as const
 
 export const ProductSort = () => {

--- a/src/components/features/product/ProductStockFilter.tsx
+++ b/src/components/features/product/ProductStockFilter.tsx
@@ -1,0 +1,38 @@
+'use client'
+// 追加 (#104): 在庫切れ非表示トグル（Client Component）
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { useCallback } from 'react'
+
+export const ProductStockFilter = () => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const isInStockOnly = searchParams.get('inStockOnly') === '1'
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (e.target.checked) {
+        params.set('inStockOnly', '1')
+      } else {
+        params.delete('inStockOnly')
+      }
+      params.delete('skip')
+      router.push(`${pathname}?${params.toString()}`)
+    },
+    [router, pathname, searchParams],
+  )
+
+  return (
+    <label className="flex items-center gap-2 text-sm text-gray-700">
+      <input
+        type="checkbox"
+        checked={isInStockOnly}
+        onChange={handleChange}
+        className="h-4 w-4 rounded border-gray-300"
+        aria-label="在庫切れを除外"
+      />
+      在庫切れを除外
+    </label>
+  )
+}

--- a/src/constants/rateLimit.ts
+++ b/src/constants/rateLimit.ts
@@ -13,6 +13,8 @@ export const RATE_LIMITS = {
   PAYMENT_INTENT: 20,
   // 画像アップロード
   ADMIN_UPLOAD: 30,
+  // 追加 (#104): 検索サジェスト
+  SEARCH_SUGGEST: 60,
 } as const
 
 export type RateLimitKey = keyof typeof RATE_LIMITS

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,0 +1,13 @@
+// 追加 (#104): 検索強化に関する定数
+
+/** 検索サジェストで返す最大件数 */
+export const SEARCH_SUGGEST_LIMIT = 8
+
+/** 検索サジェストの最小入力文字数 */
+export const SEARCH_SUGGEST_MIN_QUERY_LENGTH = 1
+
+/** 検索サジェストのデバウンス時間（ms） */
+export const SEARCH_SUGGEST_DEBOUNCE_MS = 300
+
+/** 価格レンジの上限（円） */
+export const PRICE_RANGE_MAX = 1_000_000

--- a/src/lib/db/products.ts
+++ b/src/lib/db/products.ts
@@ -2,18 +2,40 @@ import { prisma } from '@/lib/db/prisma'
 import type { Product, Prisma } from '@/generated/prisma/client'
 
 // 商品一覧取得（フィルター・ページネーション付き）
+// 変更 (#104): 価格レンジ・在庫切れ非表示・人気順ソートに対応
 export const findProducts = async (params: {
   categoryId?: string
   search?: string
   take?: number
   skip?: number
   orderBy?: Prisma.ProductOrderByWithRelationInput
+  minPrice?: number
+  maxPrice?: number
+  inStockOnly?: boolean
 }) => {
-  const { categoryId, search, take = 20, skip = 0, orderBy = { createdAt: 'desc' } } = params
+  const {
+    categoryId,
+    search,
+    take = 20,
+    skip = 0,
+    orderBy = { createdAt: 'desc' },
+    minPrice,
+    maxPrice,
+    inStockOnly,
+  } = params
+
+  // 追加 (#104): 価格レンジ条件を構築
+  const priceFilter: Prisma.IntFilter = {}
+  if (typeof minPrice === 'number') priceFilter.gte = minPrice
+  if (typeof maxPrice === 'number') priceFilter.lte = maxPrice
+  const hasPriceFilter = Object.keys(priceFilter).length > 0
+
   return prisma.product.findMany({
     where: {
       isPublished: true,
       ...(categoryId ? { categoryId } : {}),
+      ...(hasPriceFilter ? { price: priceFilter } : {}),
+      ...(inStockOnly ? { stock: { gt: 0 } } : {}),
       ...(search
         ? {
             OR: [
@@ -27,6 +49,23 @@ export const findProducts = async (params: {
     take,
     skip,
     orderBy,
+  })
+}
+
+// 追加 (#104): 検索サジェスト用（商品名 prefix 一致・公開済み）
+export const findProductSuggestions = async (params: {
+  query: string
+  limit?: number
+}) => {
+  const { query, limit = 8 } = params
+  return prisma.product.findMany({
+    where: {
+      isPublished: true,
+      name: { contains: query, mode: 'insensitive' },
+    },
+    select: { id: true, name: true },
+    take: limit,
+    orderBy: { name: 'asc' },
   })
 }
 


### PR DESCRIPTION
Closes #104

## 変更内容
- **検索サジェスト API**: `GET /api/products/search-suggest?q=...`（レートリミット 60/分）
- **ProductSearch**: 300ms debounce のサジェストドロップダウン
- **価格レンジ絞り込み**: `minPrice` / `maxPrice` searchParams + ProductPriceFilter UI
- **在庫切れ非表示トグル**: `inStockOnly=1` searchParams + ProductStockFilter UI
- **人気順ソート**: `sort=popular` で OrderItem 件数の多い順

## 受け入れ条件
- [x] サジェスト機能（debounce 300ms）
- [x] 価格レンジ絞り込み
- [x] 在庫切れ非表示トグル
- [x] 人気順ソート
- [x] サジェスト API レートリミット