### PR TITLE
feat(auth): Google OAuth ログイン (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ cp .env.example .env.local
 
 <!-- TODO: 必要な環境変数を記載してください -->
 
+### Google OAuth の設定（任意）
+
+Google ログインを有効化する場合：
+
+1. [Google Cloud Console](https://console.cloud.google.com/) で OAuth クライアント ID を作成（種類: ウェブアプリケーション）
+2. 承認済みのリダイレクト URI に `${NEXTAUTH_URL}/api/auth/callback/google`（例: `http://localhost:3000/api/auth/callback/google`）を登録
+3. `.env.local` に以下を追加
+
+```env
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+未設定の場合は Google ログインボタンが表示されません（パスワード認証のみ）。同一メールアドレスのユーザーが既に存在する場合は自動的に連携されます。
+
 ## 使い方
 
 ### 開発サーバーの起動

--- a/src/app/(shop)/login/page.tsx
+++ b/src/app/(shop)/login/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { LoginForm } from '@/components/features/auth/LoginForm'
+import { GoogleSignInButton } from '@/components/features/auth/GoogleSignInButton' // 追加 (#105)
 import { AUTH_ROUTES } from '@/constants/auth'
+import { env } from '@/env' // 追加 (#105)
 
 export const metadata: Metadata = {
   title: 'ログイン',
@@ -9,11 +11,24 @@ export const metadata: Metadata = {
 }
 
 export default function LoginPage() {
+  // 追加 (#105): Google OAuth が設定されている時のみボタンを表示
+  const isGoogleEnabled = Boolean(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET)
+
   return (
     <div className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-md flex-col justify-center px-4 py-12">
       <div className="rounded-lg border bg-card p-8 shadow-sm">
         <h1 className="mb-6 text-center text-2xl font-bold tracking-tight">ログイン</h1>
         <LoginForm />
+        {isGoogleEnabled && (
+          <>
+            <div className="my-4 flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">または</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+            <GoogleSignInButton />
+          </>
+        )}
         <p className="mt-4 text-center text-sm text-muted-foreground">
           アカウントをお持ちでない方は{' '}
           <Link

--- a/src/app/(shop)/register/page.tsx
+++ b/src/app/(shop)/register/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { RegisterForm } from '@/components/features/auth/RegisterForm'
+import { GoogleSignInButton } from '@/components/features/auth/GoogleSignInButton' // 追加 (#105)
 import { AUTH_ROUTES } from '@/constants/auth'
+import { env } from '@/env' // 追加 (#105)
 
 export const metadata: Metadata = {
   title: '会員登録',
@@ -9,11 +11,24 @@ export const metadata: Metadata = {
 }
 
 export default function RegisterPage() {
+  // 追加 (#105): Google OAuth が有効な時のみボタンを表示
+  const isGoogleEnabled = Boolean(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET)
+
   return (
     <div className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-md flex-col justify-center px-4 py-12">
       <div className="rounded-lg border bg-card p-8 shadow-sm">
         <h1 className="mb-6 text-center text-2xl font-bold tracking-tight">会員登録</h1>
         <RegisterForm />
+        {isGoogleEnabled && (
+          <>
+            <div className="my-4 flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">または</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+            <GoogleSignInButton />
+          </>
+        )}
         <p className="mt-4 text-center text-sm text-muted-foreground">
           既にアカウントをお持ちの方は{' '}
           <Link

--- a/src/components/features/auth/GoogleSignInButton.tsx
+++ b/src/components/features/auth/GoogleSignInButton.tsx
@@ -1,0 +1,47 @@
+'use client'
+// 追加 (#105): Google OAuth ログインボタン
+import { signIn } from 'next-auth/react'
+import { Button } from '@/components/ui/button'
+import { AUTH_ROUTES } from '@/constants/auth'
+
+export const GoogleSignInButton = () => {
+  const handleClick = () => {
+    void signIn('google', { callbackUrl: AUTH_ROUTES.DEFAULT_REDIRECT })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={handleClick}
+      className="w-full"
+      aria-label="Google でログイン"
+    >
+      {/* 公式 G ロゴ風 SVG */}
+      <svg
+        aria-hidden="true"
+        className="mr-2 h-4 w-4"
+        viewBox="0 0 48 48"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fill="#FFC107"
+          d="M43.611 20.083H42V20H24v8h11.303C33.972 31.91 29.36 35 24 35c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C33.046 5.053 28.793 3 24 3 12.955 3 4 11.955 4 23s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"
+        />
+        <path
+          fill="#FF3D00"
+          d="M6.306 14.691l6.571 4.819C14.655 16.108 19.001 13 24 13c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C33.046 5.053 28.793 3 24 3 16.318 3 9.656 7.337 6.306 14.691z"
+        />
+        <path
+          fill="#4CAF50"
+          d="M24 43c4.756 0 9.077-1.81 12.337-4.764l-5.703-4.83C28.74 34.91 26.475 35.5 24 35.5c-5.336 0-9.93-3.063-11.265-7.5l-6.518 5.024C9.518 39.59 16.213 43 24 43z"
+        />
+        <path
+          fill="#1976D2"
+          d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l5.703 4.83C39.099 35.91 44 30.5 44 23c0-1.341-.138-2.65-.389-3.917z"
+        />
+      </svg>
+      Google でログイン
+    </Button>
+  )
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,10 @@ const envSchema = z.object({
   NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
   SENTRY_ENVIRONMENT: z.string().optional(),
+
+  // 追加 (#105): Google OAuth（オプショナル：未設定時は Google ログインが無効化される）
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
 })
 
 // 環境変数をパース・バリデーション

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,8 +4,9 @@ import 'server-only'
 import bcrypt from 'bcryptjs'
 import NextAuth, { type DefaultSession } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
+import Google from 'next-auth/providers/google' // 追加 (#105)
 import { env } from '@/env'
-import { findUserByEmail } from '@/lib/db/users'
+import { findUserByEmail, createUser } from '@/lib/db/users' // 変更 (#105): createUser 追加
 
 // Session 型拡張：id・role フィールドを追加
 declare module 'next-auth' {
@@ -34,6 +35,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   // 変更: 開発環境のみ trustHost を有効化し本番では無効化
   trustHost: env.NODE_ENV !== 'production',
   providers: [
+    // 追加 (#105): Google OAuth プロバイダー（環境変数が設定されている時のみ有効）
+    ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+      ? [
+          Google({
+            clientId: env.GOOGLE_CLIENT_ID,
+            clientSecret: env.GOOGLE_CLIENT_SECRET,
+          }),
+        ]
+      : []),
     Credentials({
       credentials: {
         email: { label: 'メールアドレス', type: 'email' },
@@ -68,6 +78,31 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
   callbacks: {
+    // 追加 (#105): Google OAuth で初回ログイン時にユーザーを自動作成・既存ユーザーは email で連携
+    async signIn({ user, account }) {
+      if (account?.provider !== 'google') return true
+      if (!user.email) return false
+
+      const existing = await findUserByEmail(user.email)
+      if (existing) {
+        // 既存ユーザーが無効化されている場合はログイン拒否
+        if (existing.isActive === false) return false
+        // 既存ユーザーの id/role を user オブジェクトに反映（jwt callback へ伝播）
+        user.id = existing.id
+        user.role = existing.role
+        return true
+      }
+
+      // 新規 Google ユーザー：パスワードなしで作成
+      const created = await createUser({
+        email: user.email,
+        name: user.name ?? null,
+        // passwordHash 未設定（Google 認証専用）
+      })
+      user.id = created.id
+      user.role = created.role
+      return true
+    },
     // JWT にユーザー情報を追加
     jwt({ token, user }) {
       const t = token as JwtToken


### PR DESCRIPTION
Closes #105

## 変更内容
- NextAuth Google プロバイダーを **GOOGLE_CLIENT_ID/SECRET 設定時のみ** 有効化
- `signIn` callback で Email ベースの自動連携 / 新規ユーザー自動作成（passwordHash 無しで USER ロール）
- ログイン / 会員登録ページに Google ログインボタン
- README に Google Cloud Console セットアップ手順を追記

## 受け入れ条件
- [x] Google プロバイダー追加
- [x] env 変数（GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET）
- [x] ログイン / 会員登録ページにボタン
- [x] 同一メール自動連携
- [x] README 手順追記

## 注意
- Google 環境変数は **オプショナル**。CI 環境で未設定でも既存テストに影響しない
- Account モデルは追加せず、Email ベースで連携（複数 OAuth プロバイダー対応は将来課題）