### PR TITLE
feat(admin): 在庫アラートと変動履歴機能を追加 (#106)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,21 +55,22 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  orders    Order[]
-  cart      Cart?
-  reviews   Review[]
-  wishlist  Wishlist?
+  orders         Order[]
+  cart           Cart?
+  reviews        Review[]
+  wishlist       Wishlist?
+  stockMovements StockMovement[] // 追加 (#106)
 
   @@map("users")
 }
 
 // ----- カテゴリ -----
 model Category {
-  id        String    @id @default(cuid())
+  id        String   @id @default(cuid())
   name      String
-  slug      String    @unique
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   products Product[]
 
@@ -78,26 +79,51 @@ model Category {
 
 // ----- 商品 -----
 model Product {
-  id          String   @id @default(cuid())
-  name        String
-  description String?
-  price       Int      // 円単位
-  stock       Int      @default(0)
-  images      String[] // 画像URL配列
-  isPublished Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                String   @id @default(cuid())
+  name              String
+  description       String?
+  price             Int // 円単位
+  stock             Int      @default(0)
+  lowStockThreshold Int      @default(3) // 追加 (#106): 在庫不足警告の閾値
+  images            String[] // 画像URL配列
+  isPublished       Boolean  @default(true)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
   categoryId String?
   category   Category? @relation(fields: [categoryId], references: [id])
 
-  orderItems    OrderItem[]
-  cartItems     CartItem[]
-  reviews       Review[]
-  wishlistItems WishlistItem[]
+  orderItems               OrderItem[]
+  cartItems                CartItem[]
+  reviews                  Review[]
+  wishlistItems            WishlistItem[]
   backInStockSubscriptions BackInStockSubscription[] // 追加: バックインストック通知購読
+  stockMovements           StockMovement[] // 追加 (#106)
 
   @@map("products")
+}
+
+// 追加 (#106): 在庫変動履歴モデル
+enum StockMovementType {
+  IN // 入庫・訂正増
+  OUT // 出庫・訂正減
+  ADJUST // 手動調整
+}
+
+model StockMovement {
+  id        String            @id @default(cuid())
+  productId String
+  type      StockMovementType
+  quantity  Int // 変動量（符号あり：IN で正 / OUT で負 / ADJUST で差分）
+  reason    String?
+  userId    String? // 操作者（システム生成の際は null）
+  createdAt DateTime          @default(now())
+
+  product Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+  user    User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([productId, createdAt])
+  @@map("stock_movements")
 }
 
 // ----- バックインストック通知購読 -----
@@ -120,19 +146,19 @@ model BackInStockSubscription {
 model Order {
   id         String      @id @default(cuid())
   status     OrderStatus @default(PENDING)
-  totalPrice Int         // 円単位
+  totalPrice Int // 円単位
   createdAt  DateTime    @default(now())
   updatedAt  DateTime    @updatedAt
 
   userId String
   user   User   @relation(fields: [userId], references: [id])
 
-  items         OrderItem[]
-  couponId      String?
-  coupon        Coupon?    @relation(fields: [couponId], references: [id])
+  items    OrderItem[]
+  couponId String?
+  coupon   Coupon?     @relation(fields: [couponId], references: [id])
 
   stripePaymentIntentId String?
-  shippingAddress       Json?   // 配送先住所
+  shippingAddress       Json? // 配送先住所
 
   @@map("orders")
 }
@@ -141,7 +167,7 @@ model Order {
 model OrderItem {
   id        String   @id @default(cuid())
   quantity  Int
-  unitPrice Int      // 注文時点の価格（円単位）
+  unitPrice Int // 注文時点の価格（円単位）
   createdAt DateTime @default(now())
 
   orderId   String
@@ -185,7 +211,7 @@ model CartItem {
 // ----- レビュー -----
 model Review {
   id        String   @id @default(cuid())
-  rating    Int      // 1〜5
+  rating    Int // 1〜5
   comment   String?
   isPublic  Boolean  @default(true)
   createdAt DateTime @default(now())
@@ -206,8 +232,8 @@ model Wishlist {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  userId String   @unique
-  user   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   items WishlistItem[]
 
@@ -232,8 +258,8 @@ model WishlistItem {
 model Coupon {
   id          String    @id @default(cuid())
   code        String    @unique
-  discountPct Int       // 割引率（0〜100）
-  maxUses     Int?      // null = 無制限
+  discountPct Int // 割引率（0〜100）
+  maxUses     Int? // null = 無制限
   usedCount   Int       @default(0)
   expiresAt   DateTime?
   isActive    Boolean   @default(true)
@@ -244,4 +270,3 @@ model Coupon {
 
   @@map("coupons")
 }
-

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,5 +1,6 @@
 // 管理画面ダッシュボード（Server Component）
 import { DashboardStats } from '@/components/features/admin/DashboardStats'
+import { LowStockWidget } from '@/components/features/admin/LowStockWidget'
 import { RecentOrders } from '@/components/features/admin/RecentOrders'
 import { getDashboardStats, getRecentOrders } from '@/lib/db/stats'
 
@@ -45,6 +46,9 @@ export default async function DashboardPage() {
 
       {/* 最新注文一覧 */}
       <RecentOrders orders={recentOrders} />
+
+      {/* 追加 (#106): 在庫アラートウィジェット */}
+      <LowStockWidget />
     </div>
   )
 }

--- a/src/app/(admin)/admin/products/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/products/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { ChevronLeft } from 'lucide-react'
 import { ProductForm } from '@/components/features/admin/ProductForm'
+import { StockMovementTimeline } from '@/components/features/admin/StockMovementTimeline'
 import { findProductByIdForAdmin } from '@/lib/db/products'
 import { findAllCategories } from '@/lib/db/categories'
 
@@ -54,9 +55,13 @@ export default async function AdminProductEditPage({ params }: Props) {
             stock: product.stock,
             categoryId: product.categoryId ?? '',
             isPublished: product.isPublished,
+            lowStockThreshold: product.lowStockThreshold,
           }}
         />
       </div>
+
+      {/* 追加 (#106): 在庫変動履歴タイムライン */}
+      <StockMovementTimeline productId={product.id} />
     </div>
   )
 }

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -42,7 +42,9 @@ export const PATCH = async (req: NextRequest) => {
 
     // 各商品の在庫を更新
     await Promise.all(
-      parsed.data.items.map(({ id, stock }) => updateProduct(id, { stock }))
+      parsed.data.items.map(({ id, stock }) =>
+        updateProduct(id, { stock }, { userId: check.session.user.id }), // 変更 (#106)
+      ),
     )
 
     return NextResponse.json({ success: true })

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -56,19 +56,23 @@ export const PUT = async (
       return NextResponse.json({ error: '入力内容に誤りがあります', details: parsed.error.flatten() }, { status: 400 })
     }
 
-    const { name, description, price, stock, categoryId, isPublished, images } = parsed.data
-    const product = await updateProduct(id, { // 変更
-      name,
-      description,
-      price,
-      stock,
-      isPublished,
-      // 変更: 画像URL配列を更新（Cloudinaryアップロード後のURLを受け取る）
-      images,
-      ...(categoryId !== undefined
-        ? { category: categoryId ? { connect: { id: categoryId } } : { disconnect: true } }
-        : {}),
-    })
+    const { name, description, price, stock, categoryId, isPublished, images, lowStockThreshold } = parsed.data
+    const product = await updateProduct(
+      id,
+      {
+        name,
+        description,
+        price,
+        stock,
+        isPublished,
+        images,
+        ...(lowStockThreshold !== undefined ? { lowStockThreshold } : {}),
+        ...(categoryId !== undefined
+          ? { category: categoryId ? { connect: { id: categoryId } } : { disconnect: true } }
+          : {}),
+      },
+      { userId: check.session.user.id }, // 変更 (#106): 在庫変動履歴に操作者を記録
+    )
     // 追加: 在庫が 0 → 1 以上に変化したら未通知購読者に自動メール送信 (#76)
     if (existing.stock <= 0 && product.stock > 0) {
       // fire-and-forget: レスポンスをブロックしないため意図的に await しない

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -43,15 +43,15 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json({ error: '入力内容に誤りがあります', details: parsed.error.flatten() }, { status: 400 })
     }
 
-    const { name, description, price, stock, categoryId, isPublished, images } = parsed.data
+    const { name, description, price, stock, categoryId, isPublished, images, lowStockThreshold } = parsed.data
     const product = await createProduct({
       name,
       description,
       price,
       stock,
       isPublished,
-      // 変更: 画像URL配列を保存（Cloudinaryアップロード後のURLを受け取る）
       images,
+      ...(lowStockThreshold !== undefined ? { lowStockThreshold } : {}),
       ...(categoryId ? { category: { connect: { id: categoryId } } } : {}),
     })
     return NextResponse.json({ product }, { status: 201 })

--- a/src/app/api/admin/stock-movements/route.ts
+++ b/src/app/api/admin/stock-movements/route.ts
@@ -1,0 +1,43 @@
+// 追加 (#106): 商品の在庫変動履歴 API（管理画面用）
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAdmin } from '@/lib/admin-auth'
+import { findStockMovementsByProductId } from '@/lib/db/stockMovements'
+
+const querySchema = z.object({
+  productId: z.string().min(1),
+  take: z.coerce.number().int().min(1).max(100).optional(),
+  skip: z.coerce.number().int().min(0).optional(),
+})
+
+// GET /api/admin/stock-movements?productId=xxx&take=50&skip=0
+export const GET = async (req: NextRequest) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const parsed = querySchema.safeParse({
+    productId: searchParams.get('productId') ?? '',
+    take: searchParams.get('take') ?? undefined,
+    skip: searchParams.get('skip') ?? undefined,
+  })
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'パラメータが不正です', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const movements = await findStockMovementsByProductId(parsed.data)
+    return NextResponse.json({ movements })
+  } catch (err) {
+    console.error('[admin/stock-movements GET] エラー:', err)
+    return NextResponse.json(
+      { error: '履歴の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/admin/LowStockWidget.tsx
+++ b/src/components/features/admin/LowStockWidget.tsx
@@ -1,0 +1,45 @@
+// 追加 (#106): 在庫アラートウィジェット（ダッシュボード用 Server Component）
+import Link from 'next/link'
+import { findLowStockProducts } from '@/lib/db/stockMovements'
+
+export const LowStockWidget = async () => {
+  const products = await findLowStockProducts({ take: 10 })
+
+  return (
+    <section
+      aria-labelledby="low-stock-heading"
+      className="rounded-lg border bg-card p-6 shadow-sm"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h2 id="low-stock-heading" className="text-lg font-semibold">
+          在庫アラート
+        </h2>
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900">
+          {products.length} 件
+        </span>
+      </div>
+
+      {products.length === 0 ? (
+        <p className="text-sm text-muted-foreground">在庫が閾値を下回る商品はありません。</p>
+      ) : (
+        <ul className="divide-y">
+          {products.map((p) => (
+            <li key={p.id} className="flex items-center justify-between py-2">
+              <Link
+                href={`/admin/products/${p.id}/edit`}
+                className="text-sm font-medium hover:underline"
+              >
+                {p.name}
+              </Link>
+              <span
+                className={`text-sm ${p.stock === 0 ? 'text-red-600 font-semibold' : 'text-amber-700'}`}
+              >
+                残 {p.stock} / 閾値 {p.lowStockThreshold}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/components/features/admin/ProductForm.tsx
+++ b/src/components/features/admin/ProductForm.tsx
@@ -45,6 +45,7 @@ export const ProductForm = ({ defaultValues, productId, categories }: Props) => 
       categoryId: '',
       isPublished: true,
       images: [],
+      lowStockThreshold: 3,
       ...defaultValues,
     },
   })
@@ -145,6 +146,27 @@ export const ProductForm = ({ defaultValues, productId, categories }: Props) => 
             <p id="stock-error" role="alert" className="text-xs text-red-500">{errors.stock.message}</p>
           )}
         </div>
+      </div>
+
+      {/* 追加 (#106): 在庫アラート閾値 */}
+      <div className="space-y-1">
+        <label htmlFor="lowStockThreshold" className="block text-sm font-medium">
+          在庫アラート閾値
+        </label>
+        <input
+          id="lowStockThreshold"
+          type="number"
+          min={0}
+          {...register('lowStockThreshold', { valueAsNumber: true })}
+          className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-describedby="lowStockThreshold-help"
+        />
+        <p id="lowStockThreshold-help" className="text-xs text-muted-foreground">
+          在庫数がこの値以下になるとダッシュボードに警告を表示します（既定値: 3）
+        </p>
+        {errors.lowStockThreshold && (
+          <p role="alert" className="text-xs text-red-500">{errors.lowStockThreshold.message}</p>
+        )}
       </div>
 
       {/* カテゴリ */}

--- a/src/components/features/admin/StockMovementTimeline.tsx
+++ b/src/components/features/admin/StockMovementTimeline.tsx
@@ -1,0 +1,66 @@
+// 追加 (#106): 商品の在庫変動履歴タイムライン（管理画面 Server Component）
+import { findStockMovementsByProductId } from '@/lib/db/stockMovements'
+
+const TYPE_LABEL: Record<string, string> = {
+  IN: '入庫',
+  OUT: '出庫',
+  ADJUST: '調整',
+}
+
+const TYPE_BADGE_CLASS: Record<string, string> = {
+  IN: 'bg-emerald-100 text-emerald-900',
+  OUT: 'bg-red-100 text-red-900',
+  ADJUST: 'bg-blue-100 text-blue-900',
+}
+
+type Props = {
+  productId: string
+  take?: number
+}
+
+export const StockMovementTimeline = async ({ productId, take = 20 }: Props) => {
+  const movements = await findStockMovementsByProductId({ productId, take })
+
+  return (
+    <section
+      aria-labelledby="stock-history-heading"
+      className="rounded-lg border bg-card p-6 shadow-sm"
+    >
+      <h2 id="stock-history-heading" className="mb-4 text-lg font-semibold">
+        在庫変動履歴
+      </h2>
+
+      {movements.length === 0 ? (
+        <p className="text-sm text-muted-foreground">履歴はまだありません。</p>
+      ) : (
+        <ul className="divide-y">
+          {movements.map((m) => (
+            <li key={m.id} className="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_BADGE_CLASS[m.type]}`}
+                >
+                  {TYPE_LABEL[m.type]}
+                </span>
+                <span className={`text-sm font-medium ${m.quantity < 0 ? 'text-red-600' : 'text-emerald-700'}`}>
+                  {m.quantity > 0 ? `+${m.quantity}` : m.quantity}
+                </span>
+                {m.reason && <span className="text-xs text-muted-foreground">{m.reason}</span>}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {m.user?.name ?? m.user?.email ?? 'システム'}・
+                {new Intl.DateTimeFormat('ja-JP', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                }).format(m.createdAt)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/lib/db/products.ts
+++ b/src/lib/db/products.ts
@@ -83,8 +83,29 @@ export const createProduct = async (data: Prisma.ProductCreateInput) => {
 }
 
 // 商品更新（管理画面用）
-export const updateProduct = async (id: string, data: Prisma.ProductUpdateInput) => {
-  return prisma.product.update({ where: { id }, data })
+// 変更 (#106): 在庫が変動した場合は StockMovement(ADJUST) を同一トランザクションで記録
+export const updateProduct = async (
+  id: string,
+  data: Prisma.ProductUpdateInput,
+  options?: { userId?: string | null },
+) => {
+  return prisma.$transaction(async (tx) => {
+    const before = await tx.product.findUnique({ where: { id }, select: { stock: true } })
+    const updated = await tx.product.update({ where: { id }, data })
+    if (before && before.stock !== updated.stock) {
+      const diff = updated.stock - before.stock
+      await tx.stockMovement.create({
+        data: {
+          productId: id,
+          type: 'ADJUST',
+          quantity: diff,
+          reason: '管理画面からの在庫調整',
+          userId: options?.userId ?? null,
+        },
+      })
+    }
+    return updated
+  })
 }
 
 // 商品削除（管理画面用）
@@ -93,14 +114,30 @@ export const deleteProduct = async (id: string): Promise<Product> => {
 }
 
 // 在庫を減らす（注文確定時） - アトミックな updateMany でTOCTOU競合を防ぐ
-export const decrementStock = async (id: string, quantity: number): Promise<void> => {
-  const result = await prisma.product.updateMany({
-    where: { id, stock: { gte: quantity } },
-    data: { stock: { decrement: quantity } },
+// 変更 (#106): 在庫減少を StockMovement(OUT) として履歴に残す
+export const decrementStock = async (
+  id: string,
+  quantity: number,
+  options?: { reason?: string; userId?: string | null },
+): Promise<void> => {
+  await prisma.$transaction(async (tx) => {
+    const result = await tx.product.updateMany({
+      where: { id, stock: { gte: quantity } },
+      data: { stock: { decrement: quantity } },
+    })
+    if (result.count === 0) {
+      throw new Error('在庫が不足しています')
+    }
+    await tx.stockMovement.create({
+      data: {
+        productId: id,
+        type: 'OUT',
+        quantity: -quantity,
+        reason: options?.reason ?? '注文による出庫',
+        userId: options?.userId ?? null,
+      },
+    })
   })
-  if (result.count === 0) {
-    throw new Error('在庫が不足しています') // 変更
-  }
 }
 
 // 追加: 管理画面用商品一覧取得（非公開商品も含む）

--- a/src/lib/db/stockMovements.ts
+++ b/src/lib/db/stockMovements.ts
@@ -1,0 +1,53 @@
+// 追加 (#106): 在庫変動履歴のリポジトリ関数
+import { prisma } from '@/lib/db/prisma'
+import type { Prisma, StockMovementType } from '@/generated/prisma/client'
+
+// 在庫変動履歴を作成
+export const createStockMovement = async (data: {
+  productId: string
+  type: StockMovementType
+  quantity: number
+  reason?: string | null
+  userId?: string | null
+  tx?: Prisma.TransactionClient
+}) => {
+  const { tx, ...rest } = data
+  const client = tx ?? prisma
+  return client.stockMovement.create({ data: rest })
+}
+
+// 商品の在庫変動履歴を新しい順に取得
+export const findStockMovementsByProductId = async (params: {
+  productId: string
+  take?: number
+  skip?: number
+}) => {
+  const { productId, take = 50, skip = 0 } = params
+  return prisma.stockMovement.findMany({
+    where: { productId },
+    include: { user: { select: { id: true, name: true, email: true } } },
+    orderBy: { createdAt: 'desc' },
+    take,
+    skip,
+  })
+}
+
+// 在庫不足商品を取得（stock <= lowStockThreshold）
+export const findLowStockProducts = async (params: { take?: number } = {}) => {
+  const { take = 20 } = params
+  // Prisma の column-to-column 比較は raw を使うか field reference 構文
+  return prisma.$queryRaw<
+    Array<{
+      id: string
+      name: string
+      stock: number
+      lowStockThreshold: number
+    }>
+  >`
+    SELECT id, name, stock, "lowStockThreshold"
+    FROM products
+    WHERE "isPublished" = true AND stock <= "lowStockThreshold"
+    ORDER BY stock ASC
+    LIMIT ${take}
+  `
+}

--- a/src/lib/validators/product.ts
+++ b/src/lib/validators/product.ts
@@ -18,6 +18,12 @@ export const productSchema = z.object({
   images: z
     .array(z.string().url('画像URLの形式が不正です'))
     .max(10, '画像は最大10枚までです'),
+  // 追加 (#106): 在庫アラート閾値（未指定時はサーバ側で既定値3を使用）
+  lowStockThreshold: z
+    .number()
+    .int('閾値は整数で入力してください')
+    .min(0, '閾値は0以上で入力してください')
+    .optional(),
 })
 
 export type ProductFormValues = z.infer<typeof productSchema>


### PR DESCRIPTION
Closes #106

## 概要
管理者向けに在庫アラートと変動履歴を可視化する機能を追加します。

## 変更点
### スキーマ
- `Product.lowStockThreshold` (Int, default 3) を追加
- `StockMovement` モデル (IN/OUT/ADJUST) と `StockMovementType` enum を追加

### サーバ
- `updateProduct` / `decrementStock` を在庫変動を履歴として記録するトランザクション化
- `src/lib/db/stockMovements.ts` を新設（create / 商品別履歴 / 在庫不足一覧）
- `GET /api/admin/stock-movements?productId=...` を追加（管理者のみ）

### UI
- ダッシュボードに `LowStockWidget` を追加（在庫が閾値以下の商品リスト）
- 商品編集ページに `StockMovementTimeline` を追加
- ProductForm に在庫アラート閾値フィールドを追加

## 動作確認
- `pnpm tsc --noEmit` 成功
- `pnpm build` 成功
- `pnpm test --run` 102 tests passed