### PR TITLE
feat(sale): タイムセール機能を追加 (#107)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,8 +99,26 @@ model Product {
   wishlistItems            WishlistItem[]
   backInStockSubscriptions BackInStockSubscription[] // 追加: バックインストック通知購読
   stockMovements           StockMovement[] // 追加 (#106)
+  sales                    Sale[] // 追加 (#107): タイムセール
 
   @@map("products")
+}
+
+// 追加 (#107): タイムセールモデル
+model Sale {
+  id        String   @id @default(cuid())
+  productId String
+  salePrice Int // 円単位（< price）
+  startsAt  DateTime
+  endsAt    DateTime
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  product Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+
+  @@index([productId, startsAt, endsAt])
+  @@map("sales")
 }
 
 // 追加 (#106): 在庫変動履歴モデル

--- a/src/app/(admin)/admin/sales/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/sales/[id]/edit/page.tsx
@@ -1,0 +1,56 @@
+// 追加 (#107): タイムセール編集ページ
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+import { SaleForm } from '@/components/features/admin/SaleForm'
+import { findSaleById } from '@/lib/db/sales'
+import { findAllProductsForAdmin } from '@/lib/db/products'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'セール編集 | 管理画面',
+}
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function AdminSaleEditPage({ params }: Props) {
+  const { id } = await params
+  const [sale, products] = await Promise.all([
+    findSaleById(id),
+    findAllProductsForAdmin({ take: 200 }),
+  ])
+  if (!sale) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <Link
+          href="/admin/sales"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft size={16} aria-hidden="true" />
+          セール一覧に戻る
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">セール編集</h1>
+        <p className="text-sm text-muted-foreground">{sale.product.name}</p>
+      </div>
+
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <SaleForm
+          saleId={sale.id}
+          products={products.map((p) => ({ id: p.id, name: p.name, price: p.price }))}
+          defaultValues={{
+            productId: sale.productId,
+            salePrice: sale.salePrice,
+            startsAt: sale.startsAt,
+            endsAt: sale.endsAt,
+            isActive: sale.isActive,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/sales/new/page.tsx
+++ b/src/app/(admin)/admin/sales/new/page.tsx
@@ -1,0 +1,35 @@
+// 追加 (#107): タイムセール新規作成ページ
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+import { SaleForm } from '@/components/features/admin/SaleForm'
+import { findAllProductsForAdmin } from '@/lib/db/products'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'セール新規作成 | 管理画面',
+}
+
+export default async function AdminSaleNewPage() {
+  const products = await findAllProductsForAdmin({ take: 200 })
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <Link
+          href="/admin/sales"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft size={16} aria-hidden="true" />
+          セール一覧に戻る
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">セール新規作成</h1>
+      </div>
+
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <SaleForm
+          products={products.map((p) => ({ id: p.id, name: p.name, price: p.price }))}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/sales/page.tsx
+++ b/src/app/(admin)/admin/sales/page.tsx
@@ -1,0 +1,36 @@
+// 追加 (#107): タイムセール管理一覧ページ
+import Link from 'next/link'
+import { Plus } from 'lucide-react'
+import { SaleTable } from '@/components/features/admin/SaleTable'
+import { findAllSales } from '@/lib/db/sales'
+
+// 管理画面はDB必須のため動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'タイムセール管理 | 管理画面',
+}
+
+export default async function AdminSalesPage() {
+  const sales = await findAllSales()
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">タイムセール管理</h1>
+          <p className="text-sm text-muted-foreground">期間限定割引の作成・編集・削除</p>
+        </div>
+        <Link
+          href="/admin/sales/new"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          <Plus size={16} aria-hidden="true" />
+          新規作成
+        </Link>
+      </div>
+
+      <SaleTable sales={sales} />
+    </div>
+  )
+}

--- a/src/app/(shop)/products/[id]/page.tsx
+++ b/src/app/(shop)/products/[id]/page.tsx
@@ -8,6 +8,7 @@ import { findProductById } from '@/lib/db/products'
 import { findReviewByUserAndProduct } from '@/lib/db/reviews'
 import { getReviewStatsByProductId } from '@/lib/db/reviews' // 追加: aggregateRating用
 import { isProductInWishlist } from '@/lib/db/wishlist' // 追加
+import { findActiveSaleForProduct } from '@/lib/db/sales' // 追加 (#107)
 import { ProductDetail } from '@/components/features/product/ProductDetail'
 import { RelatedProducts } from '@/components/features/product/RelatedProducts' // 追加 (#103)
 import { RecentlyViewedProducts } from '@/components/features/product/RecentlyViewedProducts' // 追加 (#103)
@@ -125,9 +126,10 @@ export default async function ProductDetailPage({ params }: Props) {
   // ログイン状態・レビュー済み確認
   const session = await auth()
   const userId = session?.user?.id ?? null
-  const [hasReviewed, initialIsWishlisted] = await Promise.all([
+  const [hasReviewed, initialIsWishlisted, activeSale] = await Promise.all([
     userId ? !!(await findReviewByUserAndProduct(userId, product.id)) : Promise.resolve(false),
     userId ? isProductInWishlist(userId, product.id) : Promise.resolve(false),
+    findActiveSaleForProduct(product.id), // 追加 (#107)
   ])
 
   return (
@@ -146,6 +148,7 @@ export default async function ProductDetailPage({ params }: Props) {
       <ProductDetail
         product={product}
         wishlistProps={{ isLoggedIn: !!userId, initialIsWishlisted }} // 追加
+        activeSale={activeSale} // 追加 (#107)
       />
       {/* レビューセクション */}
       <div className="container mx-auto px-4 py-8 space-y-8">

--- a/src/app/(shop)/products/page.tsx
+++ b/src/app/(shop)/products/page.tsx
@@ -6,6 +6,7 @@ import { auth } from '@/lib/auth' // 追加
 import { findProducts } from '@/lib/db/products'
 import { findAllCategories } from '@/lib/db/categories' // 変更: DB層のリポジトリ関数を使用
 import { findWishlistedProductIds } from '@/lib/db/wishlist' // 追加
+import { findActiveSalesForProducts } from '@/lib/db/sales' // 追加 (#107)
 import { ProductList } from '@/components/features/product/ProductList'
 import { ProductSearch } from '@/components/features/product/ProductSearch'
 import { ProductSort } from '@/components/features/product/ProductSort'
@@ -83,6 +84,9 @@ export default async function ProductsPage({ searchParams }: Props) {
     userId ? findWishlistedProductIds(userId) : Promise.resolve(new Set<string>()), // 追加
   ])
 
+  // 追加 (#107): 一覧表示中商品の有効セールを一括取得
+  const activeSales = await findActiveSalesForProducts(products.map((p) => p.id))
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold text-gray-900">商品一覧</h1>
@@ -119,6 +123,7 @@ export default async function ProductsPage({ searchParams }: Props) {
         products={products}
         wishlistedProductIds={wishlistedProductIds} // 追加
         isLoggedIn={!!userId} // 追加
+        activeSales={activeSales} // 追加 (#107)
       />
     </div>
   )

--- a/src/app/api/admin/sales/[id]/route.ts
+++ b/src/app/api/admin/sales/[id]/route.ts
@@ -1,0 +1,95 @@
+// 追加 (#107): タイムセール管理 API（更新・削除）
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import {
+  deleteSale,
+  findOverlappingSale,
+  findSaleById,
+  updateSale,
+} from '@/lib/db/sales'
+import { findProductByIdForAdmin } from '@/lib/db/products'
+import { saleApiSchema } from '@/lib/validators/sale'
+
+export const PUT = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+  const { id } = await params
+  const existing = await findSaleById(id)
+  if (!existing) {
+    return NextResponse.json({ error: 'セールが見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+  }
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = saleApiSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '入力内容に誤りがあります', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const { productId, salePrice, startsAt, endsAt, isActive } = parsed.data
+    const product = await findProductByIdForAdmin(productId)
+    if (!product) {
+      return NextResponse.json(
+        { error: '指定された商品が存在しません', code: 'NOT_FOUND' },
+        { status: 404 },
+      )
+    }
+    if (salePrice >= product.price) {
+      return NextResponse.json(
+        { error: 'セール価格は通常価格より低くしてください', code: 'INVALID_PRICE' },
+        { status: 400 },
+      )
+    }
+
+    const overlap = await findOverlappingSale({
+      productId,
+      startsAt,
+      endsAt,
+      excludeId: id,
+    })
+    if (overlap) {
+      return NextResponse.json(
+        { error: '同じ期間に有効なセールが既に存在します', code: 'OVERLAP' },
+        { status: 409 },
+      )
+    }
+
+    const sale = await updateSale(id, { salePrice, startsAt, endsAt, isActive })
+    return NextResponse.json({ sale })
+  } catch (err) {
+    console.error('[admin/sales PUT] エラー:', err)
+    return NextResponse.json(
+      { error: 'セールの更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+export const DELETE = async (
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+  const { id } = await params
+  try {
+    await deleteSale(id)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('[admin/sales DELETE] エラー:', err)
+    return NextResponse.json(
+      { error: 'セールの削除に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/sales/route.ts
+++ b/src/app/api/admin/sales/route.ts
@@ -1,0 +1,77 @@
+// 追加 (#107): タイムセール管理 API（一覧・作成）
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/admin-auth'
+import {
+  createSale,
+  findAllSales,
+  findOverlappingSale,
+} from '@/lib/db/sales'
+import { findProductByIdForAdmin } from '@/lib/db/products'
+import { saleApiSchema } from '@/lib/validators/sale'
+
+export const GET = async () => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+  try {
+    const sales = await findAllSales()
+    return NextResponse.json({ sales })
+  } catch (err) {
+    console.error('[admin/sales GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'セール一覧の取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+export const POST = async (req: NextRequest) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = saleApiSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '入力内容に誤りがあります', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const { productId, salePrice, startsAt, endsAt, isActive } = parsed.data
+    const product = await findProductByIdForAdmin(productId)
+    if (!product) {
+      return NextResponse.json(
+        { error: '指定された商品が存在しません', code: 'NOT_FOUND' },
+        { status: 404 },
+      )
+    }
+    if (salePrice >= product.price) {
+      return NextResponse.json(
+        { error: 'セール価格は通常価格より低くしてください', code: 'INVALID_PRICE' },
+        { status: 400 },
+      )
+    }
+
+    const overlap = await findOverlappingSale({ productId, startsAt, endsAt })
+    if (overlap) {
+      return NextResponse.json(
+        { error: '同じ期間に有効なセールが既に存在します', code: 'OVERLAP' },
+        { status: 409 },
+      )
+    }
+
+    const sale = await createSale({ productId, salePrice, startsAt, endsAt, isActive })
+    return NextResponse.json({ sale }, { status: 201 })
+  } catch (err) {
+    console.error('[admin/sales POST] エラー:', err)
+    return NextResponse.json(
+      { error: 'セールの作成に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/orders/route.test.ts
+++ b/src/app/api/orders/route.test.ts
@@ -14,6 +14,9 @@ vi.mock('@/lib/db/coupons', () => ({
   findCouponByCode: vi.fn(),
   incrementCouponUsedCountAtomic: vi.fn(),
 }))
+vi.mock('@/lib/db/sales', () => ({
+  findActiveSalesForProducts: vi.fn().mockResolvedValue(new Map()),
+}))
 vi.mock('@/lib/email/sendOrderConfirmation', () => ({
   sendOrderConfirmationEmail: vi.fn().mockResolvedValue(undefined),
 }))

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -4,6 +4,8 @@ import { auth } from '@/lib/auth'
 import { createOrder, findOrdersByUserId } from '@/lib/db/orders'
 import { validateCartItems } from '@/lib/db/products'
 import { findCouponByCode, incrementCouponUsedCountAtomic } from '@/lib/db/coupons' // 変更
+import { findActiveSalesForProducts } from '@/lib/db/sales' // 追加 (#107)
+import { getEffectivePrice } from '@/lib/sale' // 追加 (#107)
 import type { Prisma } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
 import { sendOrderConfirmationEmail } from '@/lib/email/sendOrderConfirmation' // 追加
@@ -69,8 +71,21 @@ export const POST = async (req: NextRequest) => {
     // 各商品の最新価格・在庫を DB から取得して検証
     const productData = await validateCartItems(items)
 
-    // 合計金額（税抜小計）
-    const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)
+    // 追加 (#107): セール価格をサーバ側で再計算
+    const activeSales = await findActiveSalesForProducts(
+      productData.map(({ product }) => product.id),
+    )
+    const itemsWithEffectivePrice = productData.map(({ product, quantity }) => {
+      const sale = activeSales.get(product.id) ?? null
+      const unitPrice = getEffectivePrice(product, sale)
+      return { product, quantity, unitPrice }
+    })
+
+    // 合計金額（税抜小計） - セール価格反映
+    const subtotal = itemsWithEffectivePrice.reduce(
+      (sum, { unitPrice, quantity }) => sum + unitPrice * quantity,
+      0,
+    )
 
     // クーポン検証・割引計算 // 追加
     let discountAmount = 0
@@ -120,9 +135,9 @@ export const POST = async (req: NextRequest) => {
       user: { connect: { id: session.user.id } },
       ...(couponId ? { coupon: { connect: { id: couponId } } } : {}), // 追加
       items: {
-        create: productData.map(({ product, quantity }) => ({
+        create: itemsWithEffectivePrice.map(({ product, quantity, unitPrice }) => ({
           quantity,
-          unitPrice: product.price,
+          unitPrice, // 変更 (#107): セール適用後の価格を保存
           product: { connect: { id: product.id } },
         })),
       },

--- a/src/app/api/stripe/payment-intent/route.ts
+++ b/src/app/api/stripe/payment-intent/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { validateCartItems } from '@/lib/db/products'
 import { findCouponByCode } from '@/lib/db/coupons' // 追加
+import { findActiveSalesForProducts } from '@/lib/db/sales' // 追加 (#107)
+import { getEffectivePrice } from '@/lib/sale' // 追加 (#107)
 import { stripe } from '@/lib/stripe'
 import { enforceRateLimit } from '@/lib/rateLimit'
 import { logger } from '@/lib/logger' // 追加
@@ -46,8 +48,17 @@ export const POST = async (req: NextRequest) => {
     // 各商品の最新価格・在庫を DB から取得して検証
     const productData = await validateCartItems(items)
 
-    // 合計金額（税抜小計）
-    const subtotal = productData.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0)
+    // 追加 (#107): 適用中のセールを一括取得して、各商品の有効価格を再計算
+    const activeSales = await findActiveSalesForProducts(
+      productData.map(({ product }) => product.id),
+    )
+
+    // 合計金額（税抜小計） - セール価格をサーバ側で再計算（クライアント値を信用しない）
+    const subtotal = productData.reduce((sum, { product, quantity }) => {
+      const sale = activeSales.get(product.id) ?? null
+      const effective = getEffectivePrice(product, sale)
+      return sum + effective * quantity
+    }, 0)
 
     // クーポン割引計算（適用可能なクーポンのみ） // 追加
     let discountAmount = 0

--- a/src/components/features/admin/SaleForm.tsx
+++ b/src/components/features/admin/SaleForm.tsx
@@ -1,0 +1,170 @@
+'use client'
+// 追加 (#107): タイムセールフォーム（新規作成・編集共用）
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { saleSchema, type SaleFormValues } from '@/lib/validators/sale'
+
+type ProductOption = { id: string; name: string; price: number }
+
+type Props = {
+  saleId?: string
+  products: ProductOption[]
+  defaultValues?: Partial<SaleFormValues>
+}
+
+// datetime-local 用の "YYYY-MM-DDTHH:mm" 形式に変換
+const toLocalInput = (d: Date | undefined): string => {
+  if (!d) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export const SaleForm = ({ saleId, products, defaultValues }: Props) => {
+  const router = useRouter()
+  const isEdit = Boolean(saleId)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SaleFormValues>({
+    resolver: zodResolver(saleSchema),
+    defaultValues: {
+      productId: defaultValues?.productId ?? '',
+      salePrice: defaultValues?.salePrice ?? 0,
+      // datetime-local は string なので後で coerce される
+      startsAt: defaultValues?.startsAt ?? new Date(),
+      endsAt: defaultValues?.endsAt ?? new Date(Date.now() + 24 * 60 * 60 * 1000),
+      isActive: defaultValues?.isActive ?? true,
+    },
+  })
+
+  const onSubmit = async (data: SaleFormValues) => {
+    const url = isEdit ? `/api/admin/sales/${saleId}` : '/api/admin/sales'
+    const method = isEdit ? 'PUT' : 'POST'
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!res.ok) {
+      const json: unknown = await res.json().catch(() => ({}))
+      const message =
+        json !== null &&
+        typeof json === 'object' &&
+        'error' in json &&
+        typeof (json as Record<string, unknown>).error === 'string'
+          ? ((json as Record<string, unknown>).error as string)
+          : '保存に失敗しました'
+      alert(message)
+      return
+    }
+    router.push('/admin/sales')
+    router.refresh()
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
+      <div className="space-y-1">
+        <label htmlFor="productId" className="block text-sm font-medium">
+          商品 <span className="text-red-500" aria-hidden="true">*</span>
+        </label>
+        <select
+          id="productId"
+          {...register('productId')}
+          disabled={isEdit}
+          className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-muted"
+        >
+          <option value="">商品を選択</option>
+          {products.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}（¥{p.price.toLocaleString('ja-JP')}）
+            </option>
+          ))}
+        </select>
+        {errors.productId && (
+          <p role="alert" className="text-xs text-red-500">{errors.productId.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="salePrice" className="block text-sm font-medium">
+          セール価格（円） <span className="text-red-500" aria-hidden="true">*</span>
+        </label>
+        <input
+          id="salePrice"
+          type="number"
+          min={0}
+          {...register('salePrice', { valueAsNumber: true })}
+          className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        {errors.salePrice && (
+          <p role="alert" className="text-xs text-red-500">{errors.salePrice.message}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <label htmlFor="startsAt" className="block text-sm font-medium">
+            開始日時 <span className="text-red-500" aria-hidden="true">*</span>
+          </label>
+          <input
+            id="startsAt"
+            type="datetime-local"
+            defaultValue={toLocalInput(defaultValues?.startsAt)}
+            {...register('startsAt', { valueAsDate: true })}
+            className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          {errors.startsAt && (
+            <p role="alert" className="text-xs text-red-500">{errors.startsAt.message}</p>
+          )}
+        </div>
+        <div className="space-y-1">
+          <label htmlFor="endsAt" className="block text-sm font-medium">
+            終了日時 <span className="text-red-500" aria-hidden="true">*</span>
+          </label>
+          <input
+            id="endsAt"
+            type="datetime-local"
+            defaultValue={toLocalInput(defaultValues?.endsAt)}
+            {...register('endsAt', { valueAsDate: true })}
+            className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          {errors.endsAt && (
+            <p role="alert" className="text-xs text-red-500">{errors.endsAt.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <input
+          id="isActive"
+          type="checkbox"
+          {...register('isActive')}
+          className="h-4 w-4 rounded border-gray-300 accent-primary"
+        />
+        <label htmlFor="isActive" className="text-sm font-medium">
+          有効にする
+        </label>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isSubmitting ? '保存中…' : '保存'}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/admin/sales')}
+          className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent"
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/features/admin/SaleTable.tsx
+++ b/src/components/features/admin/SaleTable.tsx
@@ -1,0 +1,125 @@
+'use client'
+// 追加 (#107): タイムセール一覧テーブル（削除ボタン付き）
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useState } from 'react'
+
+type SaleRow = {
+  id: string
+  salePrice: number
+  startsAt: Date
+  endsAt: Date
+  isActive: boolean
+  product: { id: string; name: string; price: number }
+}
+
+type Props = {
+  sales: SaleRow[]
+}
+
+const formatDate = (d: Date) =>
+  new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d)
+
+export const SaleTable = ({ sales }: Props) => {
+  const router = useRouter()
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const now = new Date()
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('このセールを削除しますか？')) return
+    setPendingId(id)
+    const res = await fetch(`/api/admin/sales/${id}`, { method: 'DELETE' })
+    setPendingId(null)
+    if (!res.ok) {
+      alert('削除に失敗しました')
+      return
+    }
+    router.refresh()
+  }
+
+  if (sales.length === 0) {
+    return (
+      <p className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+        セールはまだ登録されていません。
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border bg-card shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr>
+            <th scope="col" className="px-4 py-3 text-left font-medium">商品</th>
+            <th scope="col" className="px-4 py-3 text-right font-medium">通常価格</th>
+            <th scope="col" className="px-4 py-3 text-right font-medium">セール価格</th>
+            <th scope="col" className="px-4 py-3 text-left font-medium">期間</th>
+            <th scope="col" className="px-4 py-3 text-left font-medium">状態</th>
+            <th scope="col" className="px-4 py-3 text-right font-medium">操作</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {sales.map((s) => {
+            const isActive = s.isActive && s.startsAt <= now && s.endsAt > now
+            return (
+              <tr key={s.id}>
+                <td className="px-4 py-3">{s.product.name}</td>
+                <td className="px-4 py-3 text-right">¥{s.product.price.toLocaleString('ja-JP')}</td>
+                <td className="px-4 py-3 text-right font-medium text-red-600">
+                  ¥{s.salePrice.toLocaleString('ja-JP')}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="text-xs">{formatDate(s.startsAt)}</div>
+                  <div className="text-xs text-muted-foreground">〜 {formatDate(s.endsAt)}</div>
+                </td>
+                <td className="px-4 py-3">
+                  {isActive ? (
+                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900">
+                      開催中
+                    </span>
+                  ) : !s.isActive ? (
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      無効
+                    </span>
+                  ) : s.startsAt > now ? (
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-900">
+                      開始前
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      終了
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex justify-end gap-2">
+                    <Link
+                      href={`/admin/sales/${s.id}/edit`}
+                      className="rounded-md border px-3 py-1 text-xs hover:bg-accent"
+                    >
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(s.id)}
+                      disabled={pendingId === s.id}
+                      className="rounded-md border border-red-200 bg-red-50 px-3 py-1 text-xs text-red-700 hover:bg-red-100 disabled:opacity-50"
+                    >
+                      {pendingId === s.id ? '削除中…' : '削除'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/features/product/ProductCard.tsx
+++ b/src/components/features/product/ProductCard.tsx
@@ -1,18 +1,30 @@
 // 商品カードコンポーネント
 import Link from 'next/link'
 import Image from 'next/image'
-import type { Product, Category } from '@/generated/prisma/client'
+import type { Product, Category, Sale } from '@/generated/prisma/client'
 import { WishlistButton } from '@/components/features/wishlist/WishlistButton' // 追加
+import { getEffectivePrice, isSaleActive, getDiscountPercent } from '@/lib/sale' // 追加 (#107)
 
 type Props = {
   product: Product & { category: Category | null }
   // 追加: ウィッシュリスト状態
   isWishlisted?: boolean
   isLoggedIn?: boolean
+  // 追加 (#107): 適用中のセール
+  activeSale?: Sale | null
 }
 
-export const ProductCard = ({ product, isWishlisted = false, isLoggedIn = false }: Props) => {
+export const ProductCard = ({
+  product,
+  isWishlisted = false,
+  isLoggedIn = false,
+  activeSale = null,
+}: Props) => {
   const imageUrl = product.images[0] ?? null
+  // 追加 (#107): セール価格と表示制御
+  const effectivePrice = getEffectivePrice(product, activeSale)
+  const onSale = isSaleActive(activeSale)
+  const discountPercent = getDiscountPercent(product, activeSale)
 
   return (
     <Link
@@ -43,6 +55,12 @@ export const ProductCard = ({ product, isWishlisted = false, isLoggedIn = false 
             </span>
           </div>
         )}
+        {/* 追加 (#107): セール中バッジ */}
+        {onSale && product.stock > 0 && (
+          <span className="absolute left-2 top-2 rounded-md bg-red-600 px-2 py-0.5 text-xs font-bold text-white shadow">
+            SALE {discountPercent}%OFF
+          </span>
+        )}
         {/* 追加: ウィッシュリストボタン（右上に絶対配置） */}
         <div className="absolute right-2 top-2">
           <WishlistButton
@@ -59,9 +77,20 @@ export const ProductCard = ({ product, isWishlisted = false, isLoggedIn = false 
           <p className="mb-1 text-xs text-gray-500">{product.category.name}</p>
         )}
         <h2 className="line-clamp-2 text-sm font-medium text-gray-900">{product.name}</h2>
-        <p className="mt-1 text-base font-bold text-gray-900">
-          ¥{product.price.toLocaleString('ja-JP')}
-        </p>
+        {onSale ? (
+          <p className="mt-1 flex items-baseline gap-2">
+            <span className="text-base font-bold text-red-600">
+              ¥{effectivePrice.toLocaleString('ja-JP')}
+            </span>
+            <span className="text-xs text-gray-500 line-through">
+              ¥{product.price.toLocaleString('ja-JP')}
+            </span>
+          </p>
+        ) : (
+          <p className="mt-1 text-base font-bold text-gray-900">
+            ¥{product.price.toLocaleString('ja-JP')}
+          </p>
+        )}
       </div>
     </Link>
   )

--- a/src/components/features/product/ProductDetail.tsx
+++ b/src/components/features/product/ProductDetail.tsx
@@ -1,6 +1,8 @@
 // 商品詳細表示コンポーネント（Server Component）
 import Image from 'next/image'
+import type { Sale } from '@/generated/prisma/client'
 import type { findProductById } from '@/lib/db/products'
+import { getEffectivePrice, isSaleActive, getDiscountPercent } from '@/lib/sale'
 import { AddToCartButton } from './AddToCartButton'
 import { BackInStockForm } from './BackInStockForm' // 追加: バックインストック通知フォーム
 import { WishlistButton } from '@/components/features/wishlist/WishlistButton' // 追加
@@ -13,10 +15,16 @@ type Props = {
     isLoggedIn: boolean
     initialIsWishlisted: boolean
   }
+  // 追加 (#107): 適用中のセール
+  activeSale?: Sale | null
 }
 
-export const ProductDetail = ({ product, wishlistProps }: Props) => {
+export const ProductDetail = ({ product, wishlistProps, activeSale = null }: Props) => {
   const imageUrl = product.images[0] ?? null
+  // 追加 (#107): セール価格と表示制御
+  const effectivePrice = getEffectivePrice(product, activeSale)
+  const onSale = isSaleActive(activeSale)
+  const discountPercent = getDiscountPercent(product, activeSale)
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -61,10 +69,27 @@ export const ProductDetail = ({ product, wishlistProps }: Props) => {
           <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">{product.name}</h1>
 
           {/* 価格 */}
-          <p className="text-2xl font-bold text-gray-900">
-            ¥{product.price.toLocaleString('ja-JP')}
-            <span className="ml-1 text-sm font-normal text-gray-500">（税込）</span>
-          </p>
+          {onSale ? (
+            <div className="space-y-1">
+              <span className="inline-block rounded-md bg-red-600 px-2 py-0.5 text-xs font-bold text-white">
+                SALE {discountPercent}%OFF
+              </span>
+              <p className="flex items-baseline gap-3">
+                <span className="text-2xl font-bold text-red-600 sm:text-3xl">
+                  ¥{effectivePrice.toLocaleString('ja-JP')}
+                </span>
+                <span className="text-base text-gray-500 line-through">
+                  ¥{product.price.toLocaleString('ja-JP')}
+                </span>
+                <span className="text-sm font-normal text-gray-500">（税込）</span>
+              </p>
+            </div>
+          ) : (
+            <p className="text-2xl font-bold text-gray-900">
+              ¥{product.price.toLocaleString('ja-JP')}
+              <span className="ml-1 text-sm font-normal text-gray-500">（税込）</span>
+            </p>
+          )}
 
           {/* 在庫数 */}
           <p className={`text-sm ${product.stock > 0 ? 'text-green-600' : 'text-red-500'}`}>

--- a/src/components/features/product/ProductList.tsx
+++ b/src/components/features/product/ProductList.tsx
@@ -1,5 +1,5 @@
 // 商品一覧グリッドコンポーネント
-import type { Product, Category } from '@/generated/prisma/client'
+import type { Product, Category, Sale } from '@/generated/prisma/client'
 import { ProductCard } from './ProductCard'
 
 type Props = {
@@ -7,9 +7,16 @@ type Props = {
   // 追加: ウィッシュリスト状態
   wishlistedProductIds?: Set<string>
   isLoggedIn?: boolean
+  // 追加 (#107): 商品ID -> 適用中セールのマップ
+  activeSales?: Map<string, Sale>
 }
 
-export const ProductList = ({ products, wishlistedProductIds, isLoggedIn = false }: Props) => {
+export const ProductList = ({
+  products,
+  wishlistedProductIds,
+  isLoggedIn = false,
+  activeSales,
+}: Props) => {
   if (products.length === 0) {
     return (
       <div className="py-16 text-center">
@@ -24,8 +31,9 @@ export const ProductList = ({ products, wishlistedProductIds, isLoggedIn = false
         <ProductCard
           key={product.id}
           product={product}
-          isWishlisted={wishlistedProductIds?.has(product.id) ?? false} // 追加
-          isLoggedIn={isLoggedIn} // 追加
+          isWishlisted={wishlistedProductIds?.has(product.id) ?? false}
+          isLoggedIn={isLoggedIn}
+          activeSale={activeSales?.get(product.id) ?? null}
         />
       ))}
     </div>

--- a/src/components/layouts/AdminHeader.tsx
+++ b/src/components/layouts/AdminHeader.tsx
@@ -77,6 +77,13 @@ export const AdminHeader = () => {
           >
             メールテンプレート
           </Link>
+          {/* 追加 (#107): タイムセール管理 */}
+          <Link
+            href="/admin/sales"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            タイムセール
+          </Link>
         </nav>
       </div>
     </header>

--- a/src/lib/db/sales.ts
+++ b/src/lib/db/sales.ts
@@ -1,0 +1,88 @@
+// 追加 (#107): タイムセールのリポジトリ関数
+import { prisma } from '@/lib/db/prisma'
+import type { Prisma, Sale } from '@/generated/prisma/client'
+
+// 商品の現在有効なセールを取得
+export const findActiveSaleForProduct = async (
+  productId: string,
+  now: Date = new Date(),
+): Promise<Sale | null> => {
+  return prisma.sale.findFirst({
+    where: {
+      productId,
+      isActive: true,
+      startsAt: { lte: now },
+      endsAt: { gt: now },
+    },
+    orderBy: { salePrice: 'asc' },
+  })
+}
+
+// 複数商品の有効セールを一括取得（productId -> Sale）
+export const findActiveSalesForProducts = async (
+  productIds: string[],
+  now: Date = new Date(),
+): Promise<Map<string, Sale>> => {
+  if (productIds.length === 0) return new Map()
+  const sales = await prisma.sale.findMany({
+    where: {
+      productId: { in: productIds },
+      isActive: true,
+      startsAt: { lte: now },
+      endsAt: { gt: now },
+    },
+    orderBy: { salePrice: 'asc' },
+  })
+  const map = new Map<string, Sale>()
+  for (const s of sales) {
+    if (!map.has(s.productId)) map.set(s.productId, s)
+  }
+  return map
+}
+
+// セール一覧（管理画面用）
+export const findAllSales = async () => {
+  return prisma.sale.findMany({
+    include: { product: { select: { id: true, name: true, price: true } } },
+    orderBy: { startsAt: 'desc' },
+  })
+}
+
+export const findSaleById = async (id: string) => {
+  return prisma.sale.findUnique({
+    where: { id },
+    include: { product: { select: { id: true, name: true, price: true } } },
+  })
+}
+
+export const createSale = async (data: Prisma.SaleUncheckedCreateInput) => {
+  return prisma.sale.create({ data })
+}
+
+export const updateSale = async (id: string, data: Prisma.SaleUpdateInput) => {
+  return prisma.sale.update({ where: { id }, data })
+}
+
+export const deleteSale = async (id: string): Promise<Sale> => {
+  return prisma.sale.delete({ where: { id } })
+}
+
+// 同一商品の期間重複チェック（指定期間に重なる別セールがあるか）
+export const findOverlappingSale = async (params: {
+  productId: string
+  startsAt: Date
+  endsAt: Date
+  excludeId?: string
+}) => {
+  const { productId, startsAt, endsAt, excludeId } = params
+  return prisma.sale.findFirst({
+    where: {
+      productId,
+      isActive: true,
+      ...(excludeId ? { id: { not: excludeId } } : {}),
+      // 重なり条件: existing.startsAt < endsAt && existing.endsAt > startsAt
+      startsAt: { lt: endsAt },
+      endsAt: { gt: startsAt },
+    },
+  })
+}

--- a/src/lib/sale.test.ts
+++ b/src/lib/sale.test.ts
@@ -1,0 +1,72 @@
+// 追加 (#107): タイムセール sale.ts ユニットテスト
+import { describe, it, expect } from 'vitest'
+import type { Sale } from '@/generated/prisma/client'
+import { getEffectivePrice, isSaleActive, getDiscountPercent } from '@/lib/sale'
+
+const product = { id: 'p1', price: 1000 }
+const now = new Date('2025-01-15T12:00:00Z')
+
+const buildSale = (overrides: Partial<Sale> = {}): Sale => ({
+  id: 's1',
+  productId: 'p1',
+  salePrice: 800,
+  startsAt: new Date('2025-01-10T00:00:00Z'),
+  endsAt: new Date('2025-01-20T00:00:00Z'),
+  isActive: true,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+  updatedAt: new Date('2025-01-01T00:00:00Z'),
+  ...overrides,
+})
+
+describe('getEffectivePrice', () => {
+  it('セールが null の場合は通常価格を返す', () => {
+    expect(getEffectivePrice(product, null, now)).toBe(1000)
+  })
+
+  it('適用中のセール価格を返す', () => {
+    expect(getEffectivePrice(product, buildSale(), now)).toBe(800)
+  })
+
+  it('isActive=false の場合は通常価格', () => {
+    expect(getEffectivePrice(product, buildSale({ isActive: false }), now)).toBe(1000)
+  })
+
+  it('期間外（開始前）は通常価格', () => {
+    const before = new Date('2025-01-05T00:00:00Z')
+    expect(getEffectivePrice(product, buildSale(), before)).toBe(1000)
+  })
+
+  it('期間外（終了後）は通常価格', () => {
+    const after = new Date('2025-01-25T00:00:00Z')
+    expect(getEffectivePrice(product, buildSale(), after)).toBe(1000)
+  })
+
+  it('salePrice >= price の異常データは通常価格', () => {
+    expect(getEffectivePrice(product, buildSale({ salePrice: 1200 }), now)).toBe(1000)
+  })
+})
+
+describe('isSaleActive', () => {
+  it('期間内かつ isActive=true で true', () => {
+    expect(isSaleActive(buildSale(), now)).toBe(true)
+  })
+
+  it('null は false', () => {
+    expect(isSaleActive(null, now)).toBe(false)
+  })
+
+  it('終了時刻ちょうどは false（半開区間）', () => {
+    const sale = buildSale()
+    expect(isSaleActive(sale, sale.endsAt)).toBe(false)
+  })
+})
+
+describe('getDiscountPercent', () => {
+  it('20%引きを正しく計算', () => {
+    expect(getDiscountPercent(product, buildSale(), now)).toBe(20)
+  })
+
+  it('セールなしは 0%', () => {
+    expect(getDiscountPercent(product, null, now)).toBe(0)
+  })
+})

--- a/src/lib/sale.ts
+++ b/src/lib/sale.ts
@@ -1,0 +1,35 @@
+// 追加 (#107): タイムセール価格適用ヘルパー
+import type { Sale } from '@/generated/prisma/client'
+
+type ProductLike = { id: string; price: number }
+
+// 適用中のセールがあれば salePrice を、なければ通常価格を返す
+export const getEffectivePrice = (
+  product: ProductLike,
+  sale: Sale | null | undefined,
+  now: Date = new Date(),
+): number => {
+  if (!sale) return product.price
+  if (!sale.isActive) return product.price
+  if (sale.startsAt > now) return product.price
+  if (sale.endsAt <= now) return product.price
+  if (sale.salePrice >= product.price) return product.price
+  return sale.salePrice
+}
+
+// セールが現在適用中か
+export const isSaleActive = (sale: Sale | null | undefined, now: Date = new Date()): boolean => {
+  if (!sale) return false
+  return sale.isActive && sale.startsAt <= now && sale.endsAt > now
+}
+
+// 割引率（%）。セール非適用なら 0
+export const getDiscountPercent = (
+  product: ProductLike,
+  sale: Sale | null | undefined,
+  now: Date = new Date(),
+): number => {
+  const effective = getEffectivePrice(product, sale, now)
+  if (effective >= product.price || product.price === 0) return 0
+  return Math.round(((product.price - effective) / product.price) * 100)
+}

--- a/src/lib/validators/sale.ts
+++ b/src/lib/validators/sale.ts
@@ -1,0 +1,38 @@
+// 追加 (#107): タイムセールバリデータ
+import { z } from 'zod'
+
+// API 入力用（JSON で日時が文字列として届くので coerce する）
+export const saleApiSchema = z
+  .object({
+    productId: z.string().min(1, '商品を選択してください'),
+    salePrice: z
+      .number()
+      .int('セール価格は整数で入力してください')
+      .min(0, 'セール価格は0以上で入力してください'),
+    startsAt: z.coerce.date(),
+    endsAt: z.coerce.date(),
+    isActive: z.boolean().default(true),
+  })
+  .refine((v) => v.endsAt > v.startsAt, {
+    message: '終了日時は開始日時より後である必要があります',
+    path: ['endsAt'],
+  })
+
+// フォーム用（既に Date オブジェクトとしてバインド済みの想定）
+export const saleSchema = z
+  .object({
+    productId: z.string().min(1, '商品を選択してください'),
+    salePrice: z
+      .number()
+      .int('セール価格は整数で入力してください')
+      .min(0, 'セール価格は0以上で入力してください'),
+    startsAt: z.date({ message: '開始日時を入力してください' }),
+    endsAt: z.date({ message: '終了日時を入力してください' }),
+    isActive: z.boolean(),
+  })
+  .refine((v) => v.endsAt > v.startsAt, {
+    message: '終了日時は開始日時より後である必要があります',
+    path: ['endsAt'],
+  })
+
+export type SaleFormValues = z.infer<typeof saleSchema>


### PR DESCRIPTION
Closes #107

## 概要
商品ごとに期間限定のセール価格を設定し、ストアフロントに反映する機能を追加。
クライアント値を信用せず、payment-intent / orders API でサーバ側に再計算する。

## 変更点
### スキーマ・ヘルパー
- `Sale` モデル（productId/salePrice/startsAt/endsAt/isActive）追加
- `getEffectivePrice` / `isSaleActive` / `getDiscountPercent` ヘルパー
- バリデータ: `saleSchema` (form) / `saleApiSchema` (API coerce)

### ストアフロント
- ProductCard / ProductDetail にセールバッジ + 取消線つき価格
- 商品一覧で `findActiveSalesForProducts` で一括取得

### サーバ
- `/api/stripe/payment-intent` で有効セール価格を再計算
- `/api/orders` で OrderItem.unitPrice にセール価格を保存

### 管理画面
- `/admin/sales` 一覧 + 新規作成 + 編集 + 削除
- バリデーション: salePrice < price / endsAt > startsAt / 期間重複検出

## テスト
- `src/lib/sale.test.ts` 11 ケース追加
- `pnpm test --run` 113 tests passed
- `pnpm tsc --noEmit` / `pnpm build` 成功