### PR TITLE
feat(orders): 配送ステータス・追跡番号 + 進捗タイムライン (#118)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,12 @@ model Order {
   stripePaymentIntentId String?
   shippingAddress       Json? // 配送先住所
 
+  // 追加 (#118): 配送追跡情報
+  carrier        String? // 配送業者コード（例: yamato / sagawa / japanpost）
+  trackingNumber String? // 追跡番号
+  shippedAt      DateTime? // 発送日時（SHIPPED 遷移時に自動設定）
+  deliveredAt    DateTime? // 配達完了日時（DELIVERED 遷移時に自動設定）
+
   @@map("orders")
 }
 

--- a/src/app/api/admin/orders/[id]/shipping/route.ts
+++ b/src/app/api/admin/orders/[id]/shipping/route.ts
@@ -1,0 +1,92 @@
+// 管理画面 注文配送情報更新 API（#118）
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { CARRIER_CODES } from '@/constants/shipping'
+import { requireAdmin } from '@/lib/admin-auth'
+import { findOrderById, updateOrderShipping } from '@/lib/db/orders'
+import { sendShipmentNotificationEmail } from '@/lib/email/sendShipmentNotification'
+import { shippingAddressSchema } from '@/lib/validators/order'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+// 文字列を null/undefined に正規化（空文字や空白のみは null として扱う）
+const trimmedNullable = z
+  .union([z.string(), z.null()])
+  .optional()
+  .transform((v) => {
+    if (v === null || v === undefined) return null
+    const t = v.trim()
+    return t.length === 0 ? null : t
+  })
+
+const shippingSchema = z.object({
+  carrier: z.union([z.enum(CARRIER_CODES), z.null()]).optional().transform((v) => v ?? null),
+  trackingNumber: trimmedNullable,
+})
+
+// PUT /api/admin/orders/:id/shipping - 配送業者・追跡番号を更新
+export const PUT = async (req: NextRequest, { params }: RouteParams) => {
+  const check = await requireAdmin()
+  if ('error' in check) {
+    return NextResponse.json({ error: check.error, code: 'FORBIDDEN' }, { status: check.status })
+  }
+
+  const { id } = await params
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = shippingSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '無効な配送情報です', code: 'VALIDATION_ERROR', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    // 追跡番号が指定されているのに配送業者が指定されていない（またはその逆）はエラー
+    const { carrier, trackingNumber } = parsed.data
+    if ((carrier && !trackingNumber) || (!carrier && trackingNumber)) {
+      return NextResponse.json(
+        { error: '配送業者と追跡番号は両方指定してください', code: 'VALIDATION_ERROR' },
+        { status: 400 },
+      )
+    }
+
+    const before = await findOrderById(id)
+    if (!before) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+
+    const updated = await updateOrderShipping(id, { carrier, trackingNumber })
+    const after = await findOrderById(id)
+
+    // 追跡番号が「新規に」設定された場合のみ発送通知メールを送る
+    const trackingAdded = !before.trackingNumber && updated?.trackingNumber
+    if (trackingAdded && after?.user?.email && after.shippingAddress) {
+      const addressParsed = shippingAddressSchema.safeParse(after.shippingAddress)
+      if (addressParsed.success) {
+        await sendShipmentNotificationEmail({
+          to: after.user.email,
+          order: {
+            id: after.id,
+            shippingAddress: addressParsed.data,
+            carrier: after.carrier,
+            trackingNumber: after.trackingNumber,
+          },
+        })
+      } else {
+        console.error('[admin/orders/:id/shipping PUT] shippingAddress パース失敗:', addressParsed.error.flatten())
+      }
+    }
+
+    return NextResponse.json({ order: after })
+  } catch (err) {
+    console.error('[admin/orders/:id/shipping PUT] エラー:', err)
+    return NextResponse.json(
+      { error: '配送情報の更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -86,6 +86,9 @@ export const PUT = async (req: NextRequest, { params }: RouteParams) => {
           order: {
             id: updated.id,
             shippingAddress: addressParsed.data,
+            // 追加 (#118): 配送追跡情報（既に登録されていれば）
+            carrier: updated.carrier,
+            trackingNumber: updated.trackingNumber,
           },
         })
       } else {

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { ORDER_STATUS_CLASS, ORDER_STATUS_LABEL } from '@/constants/admin'
 import { ORDER_STATUS_TRANSITIONS } from '@/constants/orders'
+import { ShippingForm } from '@/components/features/admin/ShippingForm' // 追加 (#118)
 import type { Coupon, Order, OrderItem, OrderStatus, Product, User } from '@/generated/prisma/client'
 
 // 配送先住所の型定義
@@ -172,6 +173,13 @@ export const OrderDetail = ({ order }: Props) => {
         </div>
       )}
 
+      {/* 追加 (#118): 配送情報フォーム */}
+      <ShippingForm
+        orderId={order.id}
+        initialCarrier={order.carrier}
+        initialTrackingNumber={order.trackingNumber}
+      />
+
       {/* 注文商品 */}
       <div className="rounded-lg border bg-card shadow-sm">
         <div className="p-4 pb-0">
@@ -252,6 +260,22 @@ export const OrderDetail = ({ order }: Props) => {
             <div className="sm:col-span-2">
               <dt className="text-muted-foreground">Stripe PaymentIntent ID</dt>
               <dd className="font-mono text-xs">{order.stripePaymentIntentId}</dd>
+            </div>
+          )}
+          {order.shippedAt && (
+            <div>
+              <dt className="text-muted-foreground">発送日時</dt>
+              <dd className="font-medium">
+                {new Date(order.shippedAt).toLocaleString('ja-JP')}
+              </dd>
+            </div>
+          )}
+          {order.deliveredAt && (
+            <div>
+              <dt className="text-muted-foreground">配達日時</dt>
+              <dd className="font-medium">
+                {new Date(order.deliveredAt).toLocaleString('ja-JP')}
+              </dd>
             </div>
           )}
         </dl>

--- a/src/components/features/admin/ShippingForm.tsx
+++ b/src/components/features/admin/ShippingForm.tsx
@@ -1,0 +1,134 @@
+'use client'
+// 管理画面: 配送業者・追跡番号 編集フォーム（#118）
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { CARRIER_CODES, CARRIER_LABEL, getTrackingUrl, isCarrierCode } from '@/constants/shipping'
+
+type Props = {
+  orderId: string
+  initialCarrier: string | null
+  initialTrackingNumber: string | null
+}
+
+export const ShippingForm = ({ orderId, initialCarrier, initialTrackingNumber }: Props) => {
+  const router = useRouter()
+  const [carrier, setCarrier] = useState<string>(initialCarrier ?? '')
+  const [trackingNumber, setTrackingNumber] = useState<string>(initialTrackingNumber ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setErrorMsg(null)
+    setSuccessMsg(null)
+    setIsSaving(true)
+
+    try {
+      const res = await fetch(`/api/admin/orders/${orderId}/shipping`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          carrier: carrier || null,
+          trackingNumber: trackingNumber.trim() || null,
+        }),
+      })
+
+      if (!res.ok) {
+        const data: unknown = await res.json()
+        const msg =
+          data !== null &&
+          typeof data === 'object' &&
+          'error' in data &&
+          typeof (data as { error: unknown }).error === 'string'
+            ? (data as { error: string }).error
+            : '配送情報の更新に失敗しました'
+        setErrorMsg(msg)
+        return
+      }
+
+      setSuccessMsg('配送情報を更新しました')
+      router.refresh()
+    } catch {
+      setErrorMsg('配送情報の更新中にエラーが発生しました')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const previewUrl =
+    carrier && trackingNumber.trim() && isCarrierCode(carrier)
+      ? getTrackingUrl(carrier, trackingNumber.trim())
+      : null
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border bg-card p-4 shadow-sm">
+      <h2 className="mb-3 text-sm font-semibold">配送情報</h2>
+      {errorMsg && (
+        <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600" role="alert">
+          {errorMsg}
+        </p>
+      )}
+      {successMsg && (
+        <p className="mb-3 rounded bg-emerald-50 px-3 py-2 text-sm text-emerald-700" role="status">
+          {successMsg}
+        </p>
+      )}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <label htmlFor="carrier" className="mb-1 block text-xs font-medium">
+            配送業者
+          </label>
+          <select
+            id="carrier"
+            value={carrier}
+            onChange={(e) => setCarrier(e.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="">選択してください</option>
+            {CARRIER_CODES.map((c) => (
+              <option key={c} value={c}>
+                {CARRIER_LABEL[c]}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="trackingNumber" className="mb-1 block text-xs font-medium">
+            追跡番号
+          </label>
+          <input
+            id="trackingNumber"
+            type="text"
+            value={trackingNumber}
+            onChange={(e) => setTrackingNumber(e.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="例: 1234-5678-9012"
+          />
+        </div>
+      </div>
+      {previewUrl && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          追跡 URL:{' '}
+          <a
+            href={previewUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            {previewUrl}
+          </a>
+        </p>
+      )}
+      <div className="mt-3 flex justify-end">
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSaving ? '保存中…' : '配送情報を保存'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/features/orders/OrderDetail.tsx
+++ b/src/components/features/orders/OrderDetail.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Package } from 'lucide-react'
 import type { Order, OrderItem, Product } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
 import { OrderStatusBadge } from '@/components/features/orders/OrderStatusBadge'
+import { OrderTimeline } from '@/components/features/orders/OrderTimeline' // 追加 (#118)
 
 type OrderItemWithProduct = OrderItem & { product: Product }
 type OrderWithItems = Order & { items: OrderItemWithProduct[] }
@@ -53,6 +54,9 @@ export const OrderDetail = ({ order }: Props) => {
           </time>
         </div>
       </div>
+
+      {/* 進捗タイムライン (#118) */}
+      <OrderTimeline order={order} />
 
       {/* 注文商品 */}
       <section aria-labelledby="order-items-heading">

--- a/src/components/features/orders/OrderTimeline.tsx
+++ b/src/components/features/orders/OrderTimeline.tsx
@@ -1,0 +1,157 @@
+// 注文進捗タイムライン（#118）
+// 注文 → 支払い完了 → 発送 → 配達完了 の進捗を表示する
+import { Check, Circle, Package, Truck } from 'lucide-react'
+import type { Order } from '@/generated/prisma/client'
+import { CARRIER_LABEL, getTrackingUrl, isCarrierCode } from '@/constants/shipping'
+
+type Props = {
+  order: Pick<
+    Order,
+    'status' | 'createdAt' | 'shippedAt' | 'deliveredAt' | 'carrier' | 'trackingNumber'
+  >
+}
+
+type Step = {
+  key: 'ordered' | 'paid' | 'shipped' | 'delivered'
+  label: string
+  description: string
+  icon: typeof Check
+  reached: boolean
+  date: Date | null
+}
+
+const formatDate = (d: Date | null): string | null => {
+  if (!d) return null
+  return new Date(d).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export const OrderTimeline = ({ order }: Props) => {
+  const isCancelled = order.status === 'CANCELLED'
+
+  // 各ステップの達成状態
+  const reachedPaid = ['PAID', 'SHIPPED', 'DELIVERED'].includes(order.status)
+  const reachedShipped = ['SHIPPED', 'DELIVERED'].includes(order.status)
+  const reachedDelivered = order.status === 'DELIVERED'
+
+  const steps: Step[] = [
+    {
+      key: 'ordered',
+      label: '注文受付',
+      description: 'ご注文を受け付けました',
+      icon: Check,
+      reached: true,
+      date: order.createdAt,
+    },
+    {
+      key: 'paid',
+      label: 'お支払い完了',
+      description: 'お支払いを確認しました',
+      icon: Check,
+      reached: reachedPaid,
+      date: null,
+    },
+    {
+      key: 'shipped',
+      label: '発送済み',
+      description: '商品を発送しました',
+      icon: Truck,
+      reached: reachedShipped,
+      date: order.shippedAt,
+    },
+    {
+      key: 'delivered',
+      label: '配達完了',
+      description: '商品が届きました',
+      icon: Package,
+      reached: reachedDelivered,
+      date: order.deliveredAt,
+    },
+  ]
+
+  const trackingUrl = getTrackingUrl(order.carrier, order.trackingNumber)
+  const carrierLabel = order.carrier && isCarrierCode(order.carrier) ? CARRIER_LABEL[order.carrier] : null
+
+  if (isCancelled) {
+    return (
+      <section aria-labelledby="order-timeline-heading" className="rounded-lg border bg-card p-4">
+        <h2 id="order-timeline-heading" className="mb-2 font-semibold">
+          進捗
+        </h2>
+        <p className="text-sm text-muted-foreground">この注文はキャンセルされました。</p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby="order-timeline-heading" className="rounded-lg border bg-card p-4">
+      <h2 id="order-timeline-heading" className="mb-4 font-semibold">
+        進捗
+      </h2>
+      <ol className="space-y-4">
+        {steps.map((step) => {
+          const Icon = step.reached ? step.icon : Circle
+          const dateStr = formatDate(step.date)
+          return (
+            <li key={step.key} className="flex items-start gap-3">
+              <span
+                className={`mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border ${
+                  step.reached
+                    ? 'border-emerald-500 bg-emerald-500 text-white'
+                    : 'border-muted-foreground/30 text-muted-foreground'
+                }`}
+                aria-hidden="true"
+              >
+                <Icon size={14} />
+              </span>
+              <div className="flex-1">
+                <p className={`text-sm font-medium ${step.reached ? '' : 'text-muted-foreground'}`}>
+                  {step.label}
+                </p>
+                <p className="text-xs text-muted-foreground">{step.description}</p>
+                {dateStr && (
+                  <p className="mt-0.5 text-xs text-muted-foreground" suppressHydrationWarning>
+                    {dateStr}
+                  </p>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+
+      {/* 配送追跡情報 */}
+      {(carrierLabel || order.trackingNumber) && (
+        <div className="mt-4 rounded-md border bg-muted/30 p-3 text-sm">
+          <p className="mb-1 font-medium">配送情報</p>
+          {carrierLabel && (
+            <p className="text-muted-foreground">
+              <span className="font-medium text-foreground">配送業者:</span> {carrierLabel}
+            </p>
+          )}
+          {order.trackingNumber && (
+            <p className="text-muted-foreground">
+              <span className="font-medium text-foreground">追跡番号:</span>{' '}
+              <span className="font-mono">{order.trackingNumber}</span>
+            </p>
+          )}
+          {trackingUrl && (
+            <a
+              href={trackingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-block text-sm text-primary underline-offset-4 hover:underline"
+            >
+              配送状況を追跡する
+            </a>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/constants/shipping.test.ts
+++ b/src/constants/shipping.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { CARRIER_LABEL, getTrackingUrl, isCarrierCode } from './shipping'
+
+describe('shipping 定数', () => {
+  describe('isCarrierCode', () => {
+    it('既知のコードは true', () => {
+      expect(isCarrierCode('yamato')).toBe(true)
+      expect(isCarrierCode('sagawa')).toBe(true)
+      expect(isCarrierCode('japanpost')).toBe(true)
+    })
+    it('未知の値は false', () => {
+      expect(isCarrierCode('unknown')).toBe(false)
+      expect(isCarrierCode(null)).toBe(false)
+      expect(isCarrierCode(undefined)).toBe(false)
+      expect(isCarrierCode(123)).toBe(false)
+    })
+  })
+
+  describe('getTrackingUrl', () => {
+    it('未指定の場合は null', () => {
+      expect(getTrackingUrl(null, null)).toBeNull()
+      expect(getTrackingUrl('yamato', null)).toBeNull()
+      expect(getTrackingUrl(null, '1234')).toBeNull()
+    })
+    it('未知のキャリアは null', () => {
+      expect(getTrackingUrl('foo', '1234')).toBeNull()
+    })
+    it('既知のキャリアは URL を返す（追跡番号がエンコードされる）', () => {
+      const url = getTrackingUrl('yamato', '1234-5678')
+      expect(url).toContain('kuronekoyamato')
+      expect(url).toContain('1234-5678')
+    })
+  })
+
+  it('CARRIER_LABEL が全コードに存在する', () => {
+    expect(CARRIER_LABEL.yamato).toBeTruthy()
+    expect(CARRIER_LABEL.sagawa).toBeTruthy()
+    expect(CARRIER_LABEL.japanpost).toBeTruthy()
+  })
+})

--- a/src/constants/shipping.ts
+++ b/src/constants/shipping.ts
@@ -1,0 +1,30 @@
+// 配送関連の定数（#118）
+// クライアント・サーバー双方から参照可能（Prisma 依存なし）
+
+// 配送業者コード
+export const CARRIER_CODES = ['yamato', 'sagawa', 'japanpost'] as const
+export type CarrierCode = (typeof CARRIER_CODES)[number]
+
+// 配送業者の表示ラベル
+export const CARRIER_LABEL: Record<CarrierCode, string> = {
+  yamato: 'ヤマト運輸',
+  sagawa: '佐川急便',
+  japanpost: '日本郵便',
+}
+
+// 追跡番号から配送業者の追跡ページ URL を組み立てる
+const CARRIER_TRACKING_URL: Record<CarrierCode, (n: string) => string> = {
+  yamato: (n) => `https://toi.kuronekoyamato.co.jp/cgi-bin/tneko?number01=${encodeURIComponent(n)}`,
+  sagawa: (n) => `https://k2k.sagawa-exp.co.jp/p/sagawa/web/okurijoinput.jsp?okurijoNo=${encodeURIComponent(n)}`,
+  japanpost: (n) => `https://trackings.post.japanpost.jp/services/srv/search/?reqCodeNo1=${encodeURIComponent(n)}`,
+}
+
+// 型ガード: 文字列が CarrierCode かどうか
+export const isCarrierCode = (v: unknown): v is CarrierCode =>
+  typeof v === 'string' && (CARRIER_CODES as readonly string[]).includes(v)
+
+// 配送業者・追跡番号から追跡 URL を取得
+export const getTrackingUrl = (carrier: string | null | undefined, trackingNumber: string | null | undefined): string | null => {
+  if (!carrier || !trackingNumber || !isCarrierCode(carrier)) return null
+  return CARRIER_TRACKING_URL[carrier](trackingNumber)
+}

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -54,11 +54,44 @@ export const updateOrderStatusIfMatches = async (
   expectedCurrentStatus: OrderStatus,
   newStatus: OrderStatus,
 ): Promise<number> => {
+  // 追加 (#118): SHIPPED/DELIVERED へ遷移する際に shippedAt/deliveredAt を自動設定する
+  const data: Prisma.OrderUpdateManyMutationInput = { status: newStatus }
+  if (newStatus === 'SHIPPED') {
+    data.shippedAt = new Date()
+  } else if (newStatus === 'DELIVERED') {
+    data.deliveredAt = new Date()
+  }
   const result = await prisma.order.updateMany({
     where: { id, status: expectedCurrentStatus },
-    data: { status: newStatus },
+    data,
   })
   return result.count
+}
+
+// 追加 (#118): 配送追跡情報の更新
+// trackingNumber が新規に設定された場合、shippedAt も同時にセットする
+export const updateOrderShipping = async (
+  id: string,
+  data: { carrier: string | null; trackingNumber: string | null },
+) => {
+  const existing = await prisma.order.findUnique({
+    where: { id },
+    select: { trackingNumber: true, shippedAt: true },
+  })
+  if (!existing) return null
+
+  const updateData: Prisma.OrderUpdateInput = {
+    carrier: data.carrier,
+    trackingNumber: data.trackingNumber,
+  }
+  // 追跡番号が新規に入力された場合は発送日時を自動設定
+  if (data.trackingNumber && !existing.shippedAt) {
+    updateData.shippedAt = new Date()
+  }
+  return prisma.order.update({
+    where: { id },
+    data: updateData,
+  })
 }
 
 // 注文ステータス遷移の妥当性ルール・関数は constants/orders.ts へ移動

--- a/src/lib/email/templates/shipmentNotification.ts
+++ b/src/lib/email/templates/shipmentNotification.ts
@@ -1,11 +1,15 @@
 // 発送通知メールHTMLテンプレート
 import type { ShippingAddress } from '@/constants/checkout'
+import { CARRIER_LABEL, getTrackingUrl, isCarrierCode } from '@/constants/shipping' // 追加 (#118)
 import { escapeHtml } from '@/lib/email/utils' // 変更: 共通ユーティリティに集約
 
 // テンプレートに渡す注文情報の型
 export type ShipmentNotificationOrder = {
   id: string
   shippingAddress: ShippingAddress
+  // 追加 (#118): 配送追跡情報（任意）
+  carrier?: string | null
+  trackingNumber?: string | null
 }
 
 // 発送通知メールのHTMLを生成する純粋関数
@@ -18,6 +22,23 @@ export const renderShipmentNotificationHtml = (order: ShipmentNotificationOrder)
     TEL: ${escapeHtml(addr.phone)}
   `
 
+  // 追加 (#118): 配送業者・追跡番号セクション
+  const trackingUrl = getTrackingUrl(order.carrier, order.trackingNumber)
+  const carrierLabel = order.carrier && isCarrierCode(order.carrier) ? CARRIER_LABEL[order.carrier] : null
+  const trackingHtml = order.trackingNumber
+    ? `
+      <h2 style="font-size:16px;margin:24px 0 8px;">配送情報</h2>
+      <p style="margin:0;line-height:1.6;">
+        ${carrierLabel ? `<strong>配送業者:</strong> ${escapeHtml(carrierLabel)}<br/>` : ''}
+        <strong>追跡番号:</strong> ${escapeHtml(order.trackingNumber)}${
+          trackingUrl
+            ? `<br/><a href="${escapeHtml(trackingUrl)}" style="color:#2563eb;">配送状況を追跡する</a>`
+            : ''
+        }
+      </p>
+    `
+    : ''
+
   return `<!DOCTYPE html>
 <html lang="ja">
   <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
@@ -28,7 +49,7 @@ export const renderShipmentNotificationHtml = (order: ShipmentNotificationOrder)
 
       <h2 style="font-size:16px;margin:24px 0 8px;">配送先</h2>
       <p style="margin:0;line-height:1.6;">${addressHtml}</p>
-
+${trackingHtml}
       <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
       <p style="font-size:12px;color:#6b7280;margin:0;">本メールは自動送信されています。お問い合わせはサポートまでご連絡ください。</p>
     </div>


### PR DESCRIPTION
Closes #118

## 概要
注文に配送追跡情報（キャリア・追跡番号・発送/配達日時）を持たせ、顧客マイページに進捗タイムラインを表示する。

## 変更点
- Prisma: `Order` に `carrier`/`trackingNumber`/`shippedAt`/`deliveredAt` を追加
- 定数: `src/constants/shipping.ts` でキャリアコード・追跡 URL マップを集約
- DB: `updateOrderShipping` 追加 / ステータス `SHIPPED`・`DELIVERED` 遷移時に日時を自動設定
- API: `PUT /api/admin/orders/:id/shipping` で配送情報更新 + 発送通知メール送信
- 管理画面: 注文詳細に `ShippingForm` を追加（発送日時・配達日時の表示）
- ストアフロント: 注文詳細に進捗タイムライン（注文 → 支払い → 発送 → 配達）と追跡 URL を表示
- メールテンプレート: 発送通知に配送業者・追跡番号セクションを追加
- テスト: `shipping.ts` のユニットテスト 6 件（合計 119 tests passing）

## 受け入れ条件
- [x] schema 拡張
- [x] 管理画面 UI（発送情報入力で shippedAt 自動セット）
- [x] 顧客マイページのタイムライン表示
- [x] 発送通知メールテンプレート更新
- [x] Unit テスト追加