### PR TITLE
feat(orders): 返品・返金フローを実装 (#117)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,10 @@ enum OrderStatus {
   SHIPPED
   DELIVERED
   CANCELLED
+  // 追加 (#117): 返品・返金フロー
+  RETURN_REQUESTED
+  RETURNED
+  REFUNDED
 }
 
 // 追加: メール通知テンプレート種別
@@ -183,6 +187,13 @@ model Order {
   trackingNumber String? // 追跡番号
   shippedAt      DateTime? // 発送日時（SHIPPED 遷移時に自動設定）
   deliveredAt    DateTime? // 配達完了日時（DELIVERED 遷移時に自動設定）
+
+  // 追加 (#117): 返品・返金情報
+  returnReason     String? // 顧客が入力した返品理由
+  returnRequestedAt DateTime? // 返品申請日時
+  refundedAmount   Int? // 返金額（円）
+  refundedAt       DateTime? // 返金完了日時
+  stripeRefundId   String? // Stripe Refund ID
 
   @@map("orders")
 }

--- a/src/app/api/admin/orders/[id]/refund/route.ts
+++ b/src/app/api/admin/orders/[id]/refund/route.ts
@@ -1,0 +1,94 @@
+// 管理者 返金実行 API（#117）
+import { NextRequest, NextResponse } from 'next/server'
+import { canTransitionOrderStatus } from '@/constants/orders'
+import { requireAdmin } from '@/lib/admin-auth'
+import {
+  findOrderById,
+  markOrderRefunded,
+  updateOrderStatusIfMatches,
+} from '@/lib/db/orders'
+import { sendRefundNotificationEmail } from '@/lib/email/sendRefundNotification'
+import { stripe } from '@/lib/stripe'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+// POST /api/admin/orders/:id/refund - 管理者が返金を実行する
+// 前提: 注文ステータスが RETURNED であること
+export const POST = async (_req: NextRequest, { params }: RouteParams) => {
+  const adminCheck = await requireAdmin()
+  if ('error' in adminCheck) {
+    return NextResponse.json(
+      { error: adminCheck.error, code: 'FORBIDDEN' },
+      { status: adminCheck.status },
+    )
+  }
+
+  const { id } = await params
+
+  try {
+    const order = await findOrderById(id)
+    if (!order) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    if (!canTransitionOrderStatus(order.status, 'REFUNDED')) {
+      return NextResponse.json(
+        { error: 'この注文は返金できる状態ではありません（RETURNED 状態のみ可能）', code: 'INVALID_TRANSITION' },
+        { status: 400 },
+      )
+    }
+    if (!order.stripePaymentIntentId) {
+      return NextResponse.json(
+        { error: 'Stripe決済情報が見つからないため返金できません', code: 'NO_PAYMENT_INTENT' },
+        { status: 400 },
+      )
+    }
+    if (order.refundedAt) {
+      return NextResponse.json(
+        { error: '既に返金処理が完了しています', code: 'ALREADY_REFUNDED' },
+        { status: 400 },
+      )
+    }
+
+    // Stripe で返金実行（金額は注文合計）
+    const refund = await stripe.refunds.create({
+      payment_intent: order.stripePaymentIntentId,
+      amount: order.totalPrice,
+    })
+
+    // ステータスを REFUNDED に楽観ロックで遷移
+    const count = await updateOrderStatusIfMatches(id, 'RETURNED', 'REFUNDED')
+    if (count === 0) {
+      // Stripe 返金は成功しているため、ロギングのみで成功扱いにせずクライアントに通知
+      console.error('[admin/orders/:id/refund] ステータス更新で競合が発生:', { id, refundId: refund.id })
+      return NextResponse.json(
+        { error: 'ステータス更新で競合が発生しました。管理画面で状態を確認してください', code: 'STATUS_CHANGED' },
+        { status: 409 },
+      )
+    }
+
+    await markOrderRefunded(id, { amount: order.totalPrice, stripeRefundId: refund.id })
+
+    // 顧客へ返金完了メール送信（失敗してもAPIは成功扱い）
+    if (order.user?.email) {
+      await sendRefundNotificationEmail({
+        to: order.user.email,
+        order: {
+          id: order.id,
+          customerName: order.user.name ?? 'お客様',
+          refundedAmount: order.totalPrice,
+        },
+      })
+    }
+
+    const updated = await findOrderById(id)
+    return NextResponse.json({ order: updated, refundId: refund.id })
+  } catch (err) {
+    console.error('[admin/orders/:id/refund POST] エラー:', err)
+    return NextResponse.json(
+      { error: '返金処理に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/orders/[id]/return/route.ts
+++ b/src/app/api/orders/[id]/return/route.ts
@@ -1,0 +1,79 @@
+// 顧客 注文返品申請 API（#117）
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { auth } from '@/lib/auth'
+import { canTransitionOrderStatus } from '@/constants/orders'
+import { findOrderById, updateOrderStatusIfMatches } from '@/lib/db/orders'
+import { prisma } from '@/lib/db/prisma'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+const returnSchema = z.object({
+  reason: z.string().min(1, '返品理由を入力してください').max(500),
+})
+
+// POST /api/orders/:id/return - 顧客が返品を申請する
+export const POST = async (req: NextRequest, { params }: RouteParams) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = returnSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '無効なリクエストです', code: 'VALIDATION_ERROR', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const order = await findOrderById(id)
+    if (!order) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    // 本人の注文のみ操作可能（OWASP A01: 不適切なアクセス制御）
+    if (order.userId !== session.user.id) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    // 既に返品申請中・返品受付済・返金済の場合は重複申請不可
+    if (!canTransitionOrderStatus(order.status, 'RETURN_REQUESTED')) {
+      return NextResponse.json(
+        { error: 'この注文は返品申請できない状態です', code: 'INVALID_TRANSITION' },
+        { status: 400 },
+      )
+    }
+
+    // 楽観ロックでステータス更新
+    const count = await updateOrderStatusIfMatches(id, order.status, 'RETURN_REQUESTED')
+    if (count === 0) {
+      return NextResponse.json(
+        { error: '他の操作により注文ステータスが変更されました', code: 'STATUS_CHANGED' },
+        { status: 409 },
+      )
+    }
+
+    // 返品理由・申請日時を保存
+    await prisma.order.update({
+      where: { id },
+      data: {
+        returnReason: parsed.data.reason,
+        returnRequestedAt: new Date(),
+      },
+    })
+
+    const updated = await findOrderById(id)
+    return NextResponse.json({ order: updated })
+  } catch (err) {
+    console.error('[orders/:id/return POST] エラー:', err)
+    return NextResponse.json(
+      { error: '返品申請に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/admin/OrderDetail.tsx
+++ b/src/components/features/admin/OrderDetail.tsx
@@ -36,6 +36,10 @@ const STATUS_OPTIONS: { value: OrderStatus; label: string }[] = [
   { value: 'SHIPPED', label: '発送済' },
   { value: 'DELIVERED', label: '配達完了' },
   { value: 'CANCELLED', label: 'キャンセル' },
+  // 追加 (#117)
+  { value: 'RETURN_REQUESTED', label: '返品申請中' },
+  { value: 'RETURNED', label: '返品受付済' },
+  { value: 'REFUNDED', label: '返金済' },
 ]
 
 export const OrderDetail = ({ order }: Props) => {
@@ -76,6 +80,40 @@ export const OrderDetail = ({ order }: Props) => {
       router.refresh()
     } catch {
       setErrorMsg('ステータスの更新中にエラーが発生しました')
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  // 追加 (#117): Stripe 返金実行
+  const handleRefund = async () => {
+    if (
+      !confirm(
+        `この注文（¥${order.totalPrice.toLocaleString('ja-JP')}）を Stripe 経由で返金します。よろしいですか？\nこの操作は取り消せません。`,
+      )
+    )
+      return
+
+    setIsUpdating(true)
+    setErrorMsg(null)
+
+    try {
+      const res = await fetch(`/api/admin/orders/${order.id}/refund`, { method: 'POST' })
+      if (!res.ok) {
+        const data: unknown = await res.json().catch(() => ({}))
+        const msg =
+          data !== null &&
+          typeof data === 'object' &&
+          'error' in data &&
+          typeof (data as { error: unknown }).error === 'string'
+            ? (data as { error: string }).error
+            : '返金処理に失敗しました'
+        setErrorMsg(msg)
+        return
+      }
+      router.refresh()
+    } catch {
+      setErrorMsg('返金処理中にエラーが発生しました')
     } finally {
       setIsUpdating(false)
     }
@@ -137,6 +175,67 @@ export const OrderDetail = ({ order }: Props) => {
               )
             })}
           </div>
+        </div>
+      )}
+
+      {/* 追加 (#117): 返品・返金情報 */}
+      {(order.status === 'RETURN_REQUESTED' ||
+        order.status === 'RETURNED' ||
+        order.status === 'REFUNDED' ||
+        order.returnRequestedAt) && (
+        <div className="rounded-lg border bg-card p-4 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold">返品・返金情報</h2>
+          <dl className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+            {order.returnRequestedAt && (
+              <div>
+                <dt className="text-muted-foreground">返品申請日時</dt>
+                <dd className="font-medium">
+                  {new Date(order.returnRequestedAt).toLocaleString('ja-JP')}
+                </dd>
+              </div>
+            )}
+            {order.returnReason && (
+              <div className="sm:col-span-2">
+                <dt className="text-muted-foreground">返品理由</dt>
+                <dd className="font-medium whitespace-pre-wrap">{order.returnReason}</dd>
+              </div>
+            )}
+            {order.refundedAt && (
+              <div>
+                <dt className="text-muted-foreground">返金日時</dt>
+                <dd className="font-medium">
+                  {new Date(order.refundedAt).toLocaleString('ja-JP')}
+                </dd>
+              </div>
+            )}
+            {order.refundedAmount !== null && order.refundedAmount !== undefined && (
+              <div>
+                <dt className="text-muted-foreground">返金額</dt>
+                <dd className="font-medium">¥{order.refundedAmount.toLocaleString('ja-JP')}</dd>
+              </div>
+            )}
+            {order.stripeRefundId && (
+              <div className="sm:col-span-2">
+                <dt className="text-muted-foreground">Stripe Refund ID</dt>
+                <dd className="font-mono text-xs">{order.stripeRefundId}</dd>
+              </div>
+            )}
+          </dl>
+          {order.status === 'RETURNED' && (
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={handleRefund}
+                disabled={isUpdating}
+                className="rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Stripe で返金を実行する
+              </button>
+              <p className="mt-2 text-xs text-muted-foreground">
+                ※ 実行後、注文ステータスが「返金済」に変わり、顧客にメール通知が送信されます。
+              </p>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/features/orders/OrderDetail.tsx
+++ b/src/components/features/orders/OrderDetail.tsx
@@ -6,6 +6,7 @@ import type { Order, OrderItem, Product } from '@/generated/prisma/client'
 import type { ShippingAddress } from '@/constants/checkout'
 import { OrderStatusBadge } from '@/components/features/orders/OrderStatusBadge'
 import { OrderTimeline } from '@/components/features/orders/OrderTimeline' // 追加 (#118)
+import { ReturnRequestButton } from '@/components/features/orders/ReturnRequestButton' // 追加 (#117)
 
 type OrderItemWithProduct = OrderItem & { product: Product }
 type OrderWithItems = Order & { items: OrderItemWithProduct[] }
@@ -29,6 +30,10 @@ export const OrderDetail = ({ order }: Props) => {
 
   // shippingAddress は Json? 型なのでキャストして扱う
   const shipping = order.shippingAddress as ShippingAddress | null
+
+  // 返品申請可能かどうか（#117）: PAID/SHIPPED/DELIVERED のみ
+  const canRequestReturn =
+    order.status === 'PAID' || order.status === 'SHIPPED' || order.status === 'DELIVERED'
 
   return (
     <div className="space-y-6">
@@ -133,6 +138,47 @@ export const OrderDetail = ({ order }: Props) => {
             )}
             <p className="text-muted-foreground">TEL: {shipping.phone}</p>
           </address>
+        </section>
+      )}
+
+      {/* 返品・返金情報 (#117) */}
+      {(order.status === 'RETURN_REQUESTED' ||
+        order.status === 'RETURNED' ||
+        order.status === 'REFUNDED') && (
+        <section aria-labelledby="order-return-heading">
+          <h2 id="order-return-heading" className="mb-3 font-semibold">
+            返品・返金情報
+          </h2>
+          <div className="rounded-lg border bg-card p-4 text-sm space-y-2">
+            {order.returnRequestedAt && (
+              <p>
+                <span className="text-muted-foreground">申請日:</span>{' '}
+                {new Date(order.returnRequestedAt).toLocaleString('ja-JP')}
+              </p>
+            )}
+            {order.returnReason && (
+              <p>
+                <span className="text-muted-foreground">理由:</span> {order.returnReason}
+              </p>
+            )}
+            {order.refundedAt && order.refundedAmount !== null && (
+              <p>
+                <span className="text-muted-foreground">返金額:</span> ¥
+                {order.refundedAmount.toLocaleString()}（
+                {new Date(order.refundedAt).toLocaleString('ja-JP')}）
+              </p>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 返品申請ボタン (#117) */}
+      {canRequestReturn && (
+        <section aria-labelledby="order-return-action-heading">
+          <h2 id="order-return-action-heading" className="sr-only">
+            返品申請
+          </h2>
+          <ReturnRequestButton orderId={order.id} />
         </section>
       )}
     </div>

--- a/src/components/features/orders/ReturnRequestButton.tsx
+++ b/src/components/features/orders/ReturnRequestButton.tsx
@@ -1,0 +1,98 @@
+'use client'
+// 顧客向け 返品申請ボタン（#117）
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+type Props = {
+  orderId: string
+}
+
+export const ReturnRequestButton = ({ orderId }: Props) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = () => {
+    setError(null)
+    if (!reason.trim()) {
+      setError('返品理由を入力してください')
+      return
+    }
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/orders/${orderId}/return`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason: reason.trim() }),
+        })
+        if (!res.ok) {
+          const data: unknown = await res.json().catch(() => ({}))
+          const message =
+            data &&
+            typeof data === 'object' &&
+            'error' in data &&
+            typeof (data as { error: unknown }).error === 'string'
+              ? (data as { error: string }).error
+              : '返品申請に失敗しました'
+          setError(message)
+          return
+        }
+        setOpen(false)
+        setReason('')
+        router.refresh()
+      } catch {
+        setError('返品申請に失敗しました')
+      }
+    })
+  }
+
+  if (!open) {
+    return (
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        返品を申請する
+      </Button>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <p className="text-sm font-medium">返品理由を入力してください</p>
+      <label htmlFor="return-reason" className="sr-only">
+        返品理由
+      </label>
+      <textarea
+        id="return-reason"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        rows={4}
+        maxLength={500}
+        className="w-full rounded-md border bg-background p-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        placeholder="例: 商品に不具合があった、サイズが合わなかった など"
+      />
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button type="button" onClick={handleSubmit} disabled={isPending}>
+          {isPending ? '送信中…' : '申請する'}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            setOpen(false)
+            setError(null)
+          }}
+          disabled={isPending}
+        >
+          キャンセル
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -16,6 +16,10 @@ export const ORDER_STATUS_LABEL: Record<string, string> = {
   SHIPPED: '発送済',
   DELIVERED: '配達完了',
   CANCELLED: 'キャンセル',
+  // 追加 (#117): 返品・返金
+  RETURN_REQUESTED: '返品申請中',
+  RETURNED: '返品受付済',
+  REFUNDED: '返金済',
 }
 
 // 注文ステータスのバッジスタイル
@@ -25,6 +29,10 @@ export const ORDER_STATUS_CLASS: Record<string, string> = {
   SHIPPED: 'bg-indigo-100 text-indigo-800',
   DELIVERED: 'bg-green-100 text-green-800',
   CANCELLED: 'bg-red-100 text-red-800',
+  // 追加 (#117)
+  RETURN_REQUESTED: 'bg-orange-100 text-orange-800',
+  RETURNED: 'bg-amber-100 text-amber-800',
+  REFUNDED: 'bg-rose-100 text-rose-800',
 }
 
 // クーポン一覧ページのページサイズ // 追加

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -6,6 +6,7 @@ export const EMAIL_SUBJECTS = {
   ORDER_CONFIRMATION: 'ご注文ありがとうございます',
   SHIPMENT_NOTIFICATION: '商品を発送しました',
   BACK_IN_STOCK: '商品が再入荷しました', // 追加: バックインストック通知
+  REFUND_NOTIFICATION: '返金が完了しました', // 追加 (#117)
 } as const
 
 // 追加: メール通知テンプレートのキー（Prisma enum と一致）

--- a/src/constants/orders.test.ts
+++ b/src/constants/orders.test.ts
@@ -62,14 +62,14 @@ describe('canTransitionOrderStatus', () => {
     })
   })
 
-  describe('DELIVERED は終端状態', () => {
-    const targets: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
-    it.each(targets)('DELIVERED から %s への遷移を全て拒否する', (to) => {
+  describe('DELIVERED は返品申請のみ可能', () => {
+    const denied: OrderStatus[] = ['PENDING', 'PAID', 'SHIPPED', 'DELIVERED', 'CANCELLED']
+    it.each(denied)('DELIVERED から %s への遷移を拒否する', (to) => {
       expect(canTransitionOrderStatus('DELIVERED', to)).toBe(false)
     })
 
-    it('遷移可能リストが空配列である', () => {
-      expect(ORDER_STATUS_TRANSITIONS.DELIVERED).toEqual([])
+    it('RETURN_REQUESTED への遷移は許可する (#117)', () => {
+      expect(canTransitionOrderStatus('DELIVERED', 'RETURN_REQUESTED')).toBe(true)
     })
   })
 
@@ -81,6 +81,27 @@ describe('canTransitionOrderStatus', () => {
 
     it('遷移可能リストが空配列である', () => {
       expect(ORDER_STATUS_TRANSITIONS.CANCELLED).toEqual([])
+    })
+  })
+
+  describe('返品フロー (#117)', () => {
+    it('PAID から RETURN_REQUESTED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('PAID', 'RETURN_REQUESTED')).toBe(true)
+    })
+    it('SHIPPED から RETURN_REQUESTED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('SHIPPED', 'RETURN_REQUESTED')).toBe(true)
+    })
+    it('RETURN_REQUESTED から RETURNED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('RETURN_REQUESTED', 'RETURNED')).toBe(true)
+    })
+    it('RETURNED から REFUNDED への遷移を許可する', () => {
+      expect(canTransitionOrderStatus('RETURNED', 'REFUNDED')).toBe(true)
+    })
+    it('REFUNDED は終端状態である', () => {
+      expect(ORDER_STATUS_TRANSITIONS.REFUNDED).toEqual([])
+    })
+    it('PENDING から RETURN_REQUESTED への遷移を拒否する（未支払いなので）', () => {
+      expect(canTransitionOrderStatus('PENDING', 'RETURN_REQUESTED')).toBe(false)
     })
   })
 })

--- a/src/constants/orders.ts
+++ b/src/constants/orders.ts
@@ -8,6 +8,10 @@ export const ORDER_STATUS_LABEL: Record<OrderStatus, string> = {
   SHIPPED: '発送済み',
   DELIVERED: '配達済み',
   CANCELLED: 'キャンセル済み',
+  // 追加 (#117): 返品・返金
+  RETURN_REQUESTED: '返品申請中',
+  RETURNED: '返品受付済み',
+  REFUNDED: '返金済み',
 }
 
 // 注文ステータスバッジカラー（Tailwind クラス）
@@ -17,6 +21,10 @@ export const ORDER_STATUS_COLOR: Record<OrderStatus, string> = {
   SHIPPED: 'bg-purple-100 text-purple-800',
   DELIVERED: 'bg-green-100 text-green-800',
   CANCELLED: 'bg-gray-100 text-gray-600',
+  // 追加 (#117)
+  RETURN_REQUESTED: 'bg-orange-100 text-orange-800',
+  RETURNED: 'bg-amber-100 text-amber-800',
+  REFUNDED: 'bg-rose-100 text-rose-800',
 }
 
 // 注文履歴ページパス
@@ -27,10 +35,15 @@ export const ACCOUNT_PATH = '/account'
 // 各キーから遷移可能なステータス一覧を返す
 export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
   PENDING: ['PAID', 'CANCELLED'],
-  PAID: ['SHIPPED', 'CANCELLED'],
-  SHIPPED: ['DELIVERED', 'CANCELLED'],
-  DELIVERED: [],
+  // 変更 (#117): PAID/SHIPPED/DELIVERED から RETURN_REQUESTED への遷移を許可
+  PAID: ['SHIPPED', 'CANCELLED', 'RETURN_REQUESTED'],
+  SHIPPED: ['DELIVERED', 'CANCELLED', 'RETURN_REQUESTED'],
+  DELIVERED: ['RETURN_REQUESTED'],
   CANCELLED: [],
+  // 追加 (#117): 返品フロー
+  RETURN_REQUESTED: ['RETURNED', 'CANCELLED'], // 管理者が承認 → RETURNED、却下 → CANCELLED で履歴に残す
+  RETURNED: ['REFUNDED'], // 返金処理完了
+  REFUNDED: [],
 }
 
 // 追加: 注文ステータス遷移が妥当かを判定する純粋関数

--- a/src/lib/db/orders.ts
+++ b/src/lib/db/orders.ts
@@ -98,6 +98,21 @@ export const updateOrderShipping = async (
 // クライアント・サーバー双方から prisma 依存なしで参照できるようにするため
 export { ORDER_STATUS_TRANSITIONS, canTransitionOrderStatus } from '@/constants/orders'
 
+// 追加 (#117): 返金完了情報の保存
+export const markOrderRefunded = async (
+  id: string,
+  data: { amount: number; stripeRefundId: string },
+) => {
+  return prisma.order.update({
+    where: { id },
+    data: {
+      refundedAmount: data.amount,
+      refundedAt: new Date(),
+      stripeRefundId: data.stripeRefundId,
+    },
+  })
+}
+
 // 注文件数取得（管理画面ページネーション用）
 export const countOrders = async (params: { status?: OrderStatus } = {}) => {
   const { status } = params

--- a/src/lib/email/sendRefundNotification.ts
+++ b/src/lib/email/sendRefundNotification.ts
@@ -1,0 +1,33 @@
+import 'server-only'
+import { resend } from '@/lib/email/client'
+import { env } from '@/env'
+import { EMAIL_SUBJECTS } from '@/constants/email'
+import {
+  renderRefundNotificationHtml,
+  type RefundNotificationOrder,
+} from '@/lib/email/templates/refundNotification'
+
+type SendResult = { success: boolean; error?: string }
+
+// 返金完了メール送信（#117）
+// 失敗時も throw せず、返金処理本体に影響を与えない
+export const sendRefundNotificationEmail = async (params: {
+  to: string
+  order: RefundNotificationOrder
+}): Promise<SendResult> => {
+  const { to, order } = params
+  try {
+    const html = renderRefundNotificationHtml(order)
+    await resend.emails.send({
+      from: env.EMAIL_FROM,
+      to,
+      subject: EMAIL_SUBJECTS.REFUND_NOTIFICATION,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[sendRefundNotificationEmail] 送信失敗:', err)
+    return { success: false, error: message }
+  }
+}

--- a/src/lib/email/templates/refundNotification.ts
+++ b/src/lib/email/templates/refundNotification.ts
@@ -1,0 +1,26 @@
+// 返金完了メールテンプレート（#117）
+import { escapeHtml } from '@/lib/email/utils'
+
+export type RefundNotificationOrder = {
+  id: string
+  customerName: string
+  refundedAmount: number
+}
+
+export const renderRefundNotificationHtml = (order: RefundNotificationOrder): string => {
+  return `<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
+    <div style="max-width:600px;margin:0 auto;background-color:#ffffff;padding:32px;border-radius:8px;">
+      <h1 style="font-size:20px;margin:0 0 16px;">返金が完了しました</h1>
+      <p style="margin:0 0 16px;">${escapeHtml(order.customerName)} 様</p>
+      <p style="margin:0 0 16px;">ご返品いただいた注文の返金処理が完了しましたのでお知らせします。</p>
+      <p style="margin:0 0 8px;"><strong>注文番号:</strong> ${escapeHtml(order.id)}</p>
+      <p style="margin:0 0 24px;"><strong>返金額:</strong> ¥${order.refundedAmount.toLocaleString('ja-JP')}</p>
+      <p style="margin:0 0 16px;color:#6b7280;font-size:14px;">※ ご利用のクレジットカード会社の処理により、口座への反映までに数日〜数週間かかる場合があります。</p>
+      <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
+      <p style="font-size:12px;color:#6b7280;margin:0;">本メールは自動送信されています。お問い合わせはサポートまでご連絡ください。</p>
+    </div>
+  </body>
+</html>`
+}


### PR DESCRIPTION
Closes #117

## 概要
注文の返品・返金フローを実装。OrderStatus に新ステータスを3つ追加し、顧客が返品申請、管理者が Stripe 経由で返金できるフローを構築。

## 変更内容
- **DB スキーマ**: `OrderStatus` enum に `RETURN_REQUESTED` / `RETURNED` / `REFUNDED` を追加。`Order` モデルに `returnReason` / `returnRequestedAt` / `refundedAmount` / `refundedAt` / `stripeRefundId` を追加。
- **ステータス遷移**: `PAID`/`SHIPPED`/`DELIVERED` → `RETURN_REQUESTED` → `RETURNED` → `REFUNDED` を許可。
- **API**:
  - `POST /api/orders/[id]/return`: 顧客が返品を申請（本人確認・楽観ロック付き）
  - `POST /api/admin/orders/[id]/refund`: 管理者が Stripe `refunds.create` を呼び、`RETURNED → REFUNDED` に遷移
- **UI**:
  - 顧客 OrderDetail: 返品申請ボタン（理由 textarea 付き）と返品・返金情報セクション
  - 管理 OrderDetail: 返品情報セクションと「Stripe で返金を実行」ボタン
- **メール**: 返金完了通知テンプレート + 送信関数を追加
- **テスト**: `orders.test.ts` に新ステータス遷移のテストを追加（合計31件）

## 動作確認
- `pnpm exec tsc --noEmit` ✅
- `pnpm test` ✅ 125/125 passed
- `pnpm lint` ✅ (warnings only, all pre-existing import/order)
- `pnpm build` ✅