### PR TITLE
feat(cart): カートのDB永続化とログイン時マージを実装 (#119)

### DIFF
--- a/src/app/(shop)/layout.tsx
+++ b/src/app/(shop)/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { Header } from '@/components/layouts/Header'
 import { Footer } from '@/components/layouts/Footer'
 import { EmailVerificationBanner } from '@/components/layouts/EmailVerificationBanner' // 追加 (#120)
+import { CartMergeOnLogin } from '@/components/features/cart/CartMergeOnLogin' // 追加 (#119)
 
 type Props = {
   children: ReactNode
@@ -13,6 +14,7 @@ export default function ShopLayout({ children }: Props) {
     <div className="flex min-h-screen flex-col">
       <Header />
       <EmailVerificationBanner />
+      <CartMergeOnLogin />
       <main className="flex-1">{children}</main>
       <Footer />
     </div>

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,0 +1,165 @@
+// カート操作 API（#119）
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { auth } from '@/lib/auth'
+import { enforceRateLimit } from '@/lib/rateLimit'
+import {
+  addCartItem,
+  clearCart,
+  getOrCreateCart,
+  mergeLocalCart,
+  removeCartItem,
+  updateCartItemQuantity,
+} from '@/lib/db/carts'
+
+// GET /api/cart - 現在のカートを取得
+export const GET = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const limited = enforceRateLimit('CART_OPERATION', req)
+  if (limited) return limited
+
+  try {
+    const cart = await getOrCreateCart(session.user.id)
+    return NextResponse.json({ cart })
+  } catch (err) {
+    console.error('[cart GET] エラー:', err)
+    return NextResponse.json({ error: 'カート取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}
+
+const postSchema = z.object({
+  productId: z.string().min(1),
+  quantity: z.number().int().positive().max(100),
+})
+
+// POST /api/cart - 商品をカートに追加
+export const POST = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const limited = enforceRateLimit('CART_OPERATION', req)
+  if (limited) return limited
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = postSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'リクエスト形式が不正です', code: 'VALIDATION_ERROR' },
+        { status: 400 },
+      )
+    }
+    await addCartItem({
+      userId: session.user.id,
+      productId: parsed.data.productId,
+      quantity: parsed.data.quantity,
+    })
+    const cart = await getOrCreateCart(session.user.id)
+    return NextResponse.json({ cart })
+  } catch (err) {
+    console.error('[cart POST] エラー:', err)
+    return NextResponse.json({ error: 'カートへの追加に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}
+
+const patchSchema = z.object({
+  productId: z.string().min(1),
+  quantity: z.number().int().min(0).max(100),
+})
+
+// PATCH /api/cart - 数量更新
+export const PATCH = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const limited = enforceRateLimit('CART_OPERATION', req)
+  if (limited) return limited
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = patchSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'リクエスト形式が不正です', code: 'VALIDATION_ERROR' },
+        { status: 400 },
+      )
+    }
+    await updateCartItemQuantity({
+      userId: session.user.id,
+      productId: parsed.data.productId,
+      quantity: parsed.data.quantity,
+    })
+    const cart = await getOrCreateCart(session.user.id)
+    return NextResponse.json({ cart })
+  } catch (err) {
+    console.error('[cart PATCH] エラー:', err)
+    return NextResponse.json({ error: 'カート更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}
+
+// DELETE /api/cart - 全削除 or 単一削除（?productId=...）
+export const DELETE = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const limited = enforceRateLimit('CART_OPERATION', req)
+  if (limited) return limited
+
+  try {
+    const productId = req.nextUrl.searchParams.get('productId')
+    if (productId) {
+      await removeCartItem({ userId: session.user.id, productId })
+    } else {
+      await clearCart(session.user.id)
+    }
+    const cart = await getOrCreateCart(session.user.id)
+    return NextResponse.json({ cart })
+  } catch (err) {
+    console.error('[cart DELETE] エラー:', err)
+    return NextResponse.json({ error: 'カート削除に失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}
+
+// PUT /api/cart/merge - ローカル（ゲスト）カートをサーバーカートにマージ
+const mergeSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        productId: z.string().min(1),
+        quantity: z.number().int().positive().max(100),
+      }),
+    )
+    .max(100),
+})
+
+export const PUT = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const limited = enforceRateLimit('CART_OPERATION', req)
+  if (limited) return limited
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = mergeSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'リクエスト形式が不正です', code: 'VALIDATION_ERROR' },
+        { status: 400 },
+      )
+    }
+    await mergeLocalCart(session.user.id, parsed.data.items)
+    const cart = await getOrCreateCart(session.user.id)
+    return NextResponse.json({ cart })
+  } catch (err) {
+    console.error('[cart PUT merge] エラー:', err)
+    return NextResponse.json({ error: 'カートマージに失敗しました', code: 'INTERNAL_SERVER_ERROR' }, { status: 500 })
+  }
+}

--- a/src/components/features/cart/CartMergeOnLogin.tsx
+++ b/src/components/features/cart/CartMergeOnLogin.tsx
@@ -1,0 +1,8 @@
+'use client'
+// ログイン時にローカルカートをサーバーへマージするだけのコンポーネント（#119）
+import { useCartMergeOnLogin } from '@/hooks/useCartMergeOnLogin'
+
+export const CartMergeOnLogin = () => {
+  useCartMergeOnLogin()
+  return null
+}

--- a/src/constants/rateLimit.ts
+++ b/src/constants/rateLimit.ts
@@ -17,6 +17,8 @@ export const RATE_LIMITS = {
   SEARCH_SUGGEST: 60,
   // 追加 (#120): メール確認の再送（5分に1回）
   EMAIL_VERIFY_RESEND: 1,
+  // 追加 (#119): カート操作（API）
+  CART_OPERATION: 60,
 } as const
 
 export type RateLimitKey = keyof typeof RATE_LIMITS

--- a/src/hooks/useCartMergeOnLogin.ts
+++ b/src/hooks/useCartMergeOnLogin.ts
@@ -1,0 +1,43 @@
+'use client'
+// ログイン時にローカル（Zustand）カートをサーバーカートにマージするフック（#119）
+import { useEffect, useRef } from 'react'
+import { useSession } from 'next-auth/react'
+import { useCartStore } from '@/stores/cartStore'
+
+// ログイン直後に1回だけ実行する
+export const useCartMergeOnLogin = () => {
+  const { data: session, status } = useSession()
+  const items = useCartStore((s) => s.items)
+  const clearCart = useCartStore((s) => s.clearCart)
+  // ユーザーIDごとに重複実行を防ぐ
+  const mergedForUser = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !session?.user?.id) return
+    if (mergedForUser.current === session.user.id) return
+
+    const localItems = items.map((i) => ({ productId: i.id, quantity: i.quantity }))
+    mergedForUser.current = session.user.id
+
+    // ローカルが空ならマージ不要、サーバー取得もスキップしておく（不要な API 呼び出し防止）
+    if (localItems.length === 0) return
+
+    const run = async () => {
+      try {
+        const res = await fetch('/api/cart', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: localItems }),
+        })
+        if (res.ok) {
+          // マージ成功後、ローカルカートをクリア（以後はサーバーが正）
+          clearCart()
+        }
+      } catch {
+        // ネットワークエラー時は次回ログインで再試行
+        mergedForUser.current = null
+      }
+    }
+    run()
+  }, [status, session?.user?.id, items, clearCart])
+}

--- a/src/lib/cartMerge.test.ts
+++ b/src/lib/cartMerge.test.ts
@@ -1,0 +1,83 @@
+// computeMergedCart のユニットテスト（#119）
+import { describe, it, expect } from 'vitest'
+import { computeMergedCart } from '@/lib/cartMerge'
+
+describe('computeMergedCart', () => {
+  it('サーバーカートのみの場合はそのまま返す', () => {
+    const result = computeMergedCart(
+      [{ productId: 'p1', quantity: 2 }],
+      [],
+      new Map([['p1', 10]]),
+    )
+    expect(result).toEqual([{ productId: 'p1', quantity: 2 }])
+  })
+
+  it('ローカルカートのみの場合は在庫上限でクランプして返す', () => {
+    const result = computeMergedCart(
+      [],
+      [{ productId: 'p1', quantity: 5 }],
+      new Map([['p1', 3]]),
+    )
+    expect(result).toEqual([{ productId: 'p1', quantity: 3 }])
+  })
+
+  it('競合時は数量を合算する', () => {
+    const result = computeMergedCart(
+      [{ productId: 'p1', quantity: 2 }],
+      [{ productId: 'p1', quantity: 3 }],
+      new Map([['p1', 10]]),
+    )
+    expect(result).toEqual([{ productId: 'p1', quantity: 5 }])
+  })
+
+  it('合算後に在庫を超える場合は在庫上限でクランプする', () => {
+    const result = computeMergedCart(
+      [{ productId: 'p1', quantity: 2 }],
+      [{ productId: 'p1', quantity: 5 }],
+      new Map([['p1', 4]]),
+    )
+    expect(result).toEqual([{ productId: 'p1', quantity: 4 }])
+  })
+
+  it('在庫が0または商品が存在しないローカルアイテムは除外する', () => {
+    const result = computeMergedCart(
+      [],
+      [
+        { productId: 'p1', quantity: 2 }, // 在庫なし
+        { productId: 'p2', quantity: 1 }, // 商品なし
+        { productId: 'p3', quantity: 3 }, // OK
+      ],
+      new Map([
+        ['p1', 0],
+        ['p3', 5],
+      ]),
+    )
+    expect(result).toEqual([{ productId: 'p3', quantity: 3 }])
+  })
+
+  it('quantity が 0 以下のローカルアイテムは無視する', () => {
+    const result = computeMergedCart(
+      [{ productId: 'p1', quantity: 2 }],
+      [{ productId: 'p1', quantity: 0 }],
+      new Map([['p1', 10]]),
+    )
+    expect(result).toEqual([{ productId: 'p1', quantity: 2 }])
+  })
+
+  it('複数商品を独立にマージする', () => {
+    const result = computeMergedCart(
+      [{ productId: 'p1', quantity: 1 }],
+      [
+        { productId: 'p1', quantity: 2 },
+        { productId: 'p2', quantity: 1 },
+      ],
+      new Map([
+        ['p1', 10],
+        ['p2', 10],
+      ]),
+    )
+    expect(result).toContainEqual({ productId: 'p1', quantity: 3 })
+    expect(result).toContainEqual({ productId: 'p2', quantity: 1 })
+    expect(result).toHaveLength(2)
+  })
+})

--- a/src/lib/cartMerge.ts
+++ b/src/lib/cartMerge.ts
@@ -1,0 +1,29 @@
+// カートマージのピュアロジック（#119）
+// server-only に依存しないため Vitest で単独テスト可能
+
+export type LocalCartItem = { productId: string; quantity: number }
+export type MergedItem = { productId: string; quantity: number }
+
+// サーバーカートとローカルカートをマージし、productId 毎の最終数量を返す
+// - 同一 productId は数量を合算
+// - 合算後は stockMap の在庫上限でクランプ
+// - 在庫が0 or 不明の productId は除外
+// - quantity <= 0 のローカルアイテムは無視
+export const computeMergedCart = (
+  serverItems: { productId: string; quantity: number }[],
+  localItems: { productId: string; quantity: number }[],
+  stockMap: Map<string, number>,
+): MergedItem[] => {
+  const result = new Map<string, number>()
+  for (const s of serverItems) {
+    if (s.quantity > 0) result.set(s.productId, s.quantity)
+  }
+  for (const l of localItems) {
+    if (l.quantity <= 0) continue
+    const stock = stockMap.get(l.productId)
+    if (stock === undefined || stock <= 0) continue
+    const merged = (result.get(l.productId) ?? 0) + l.quantity
+    result.set(l.productId, Math.min(merged, stock))
+  }
+  return Array.from(result.entries()).map(([productId, quantity]) => ({ productId, quantity }))
+}

--- a/src/lib/db/carts.ts
+++ b/src/lib/db/carts.ts
@@ -1,0 +1,122 @@
+// カートDB操作（#119）
+import 'server-only'
+import { prisma } from '@/lib/db/prisma'
+export { computeMergedCart } from '@/lib/cartMerge'
+export type { LocalCartItem, MergedItem } from '@/lib/cartMerge'
+
+// ユーザーのカートを items 込みで取得（無ければ作成）
+export const getOrCreateCart = async (userId: string) => {
+  const existing = await prisma.cart.findUnique({
+    where: { userId },
+    include: { items: { include: { product: true } } },
+  })
+  if (existing) return existing
+  return prisma.cart.create({
+    data: { userId },
+    include: { items: { include: { product: true } } },
+  })
+}
+
+// アイテムを追加 or 数量加算（在庫上限でクランプ）
+export const addCartItem = async (params: {
+  userId: string
+  productId: string
+  quantity: number
+}) => {
+  const { userId, productId, quantity } = params
+  const cart = await getOrCreateCart(userId)
+  const product = await prisma.product.findUnique({ where: { id: productId } })
+  if (!product) throw new Error('商品が見つかりません')
+
+  const existing = cart.items.find((i) => i.productId === productId)
+  const desired = (existing?.quantity ?? 0) + quantity
+  // 在庫上限でクランプ
+  const clamped = Math.min(desired, product.stock)
+  if (clamped <= 0) throw new Error('在庫がありません')
+
+  if (existing) {
+    return prisma.cartItem.update({
+      where: { id: existing.id },
+      data: { quantity: clamped },
+    })
+  }
+  return prisma.cartItem.create({
+    data: { cartId: cart.id, productId, quantity: clamped },
+  })
+}
+
+// 数量更新（0以下なら削除）
+export const updateCartItemQuantity = async (params: {
+  userId: string
+  productId: string
+  quantity: number
+}) => {
+  const { userId, productId, quantity } = params
+  const cart = await getOrCreateCart(userId)
+  const item = cart.items.find((i) => i.productId === productId)
+  if (!item) return null
+
+  if (quantity <= 0) {
+    await prisma.cartItem.delete({ where: { id: item.id } })
+    return null
+  }
+  const product = await prisma.product.findUnique({ where: { id: productId } })
+  if (!product) throw new Error('商品が見つかりません')
+  const clamped = Math.min(quantity, product.stock)
+  return prisma.cartItem.update({
+    where: { id: item.id },
+    data: { quantity: clamped },
+  })
+}
+
+// アイテム削除
+export const removeCartItem = async (params: { userId: string; productId: string }) => {
+  const cart = await getOrCreateCart(params.userId)
+  const item = cart.items.find((i) => i.productId === params.productId)
+  if (!item) return false
+  await prisma.cartItem.delete({ where: { id: item.id } })
+  return true
+}
+
+// カートをクリア
+export const clearCart = async (userId: string) => {
+  const cart = await prisma.cart.findUnique({ where: { userId } })
+  if (!cart) return
+  await prisma.cartItem.deleteMany({ where: { cartId: cart.id } })
+}
+
+// マージ用: ローカルカートの items を DB カートに合算（在庫上限でクランプ）
+export const mergeLocalCart = async (
+  userId: string,
+  localItems: { productId: string; quantity: number }[],
+) => {
+  if (localItems.length === 0) return
+  const cart = await getOrCreateCart(userId)
+  // 商品在庫を一括取得
+  const products = await prisma.product.findMany({
+    where: { id: { in: localItems.map((i) => i.productId) } },
+    select: { id: true, stock: true },
+  })
+  const stockMap = new Map(products.map((p) => [p.id, p.stock]))
+
+  for (const local of localItems) {
+    if (local.quantity <= 0) continue
+    const stock = stockMap.get(local.productId)
+    if (stock === undefined || stock <= 0) continue // 商品が無効 or 在庫なし
+    const existing = cart.items.find((i) => i.productId === local.productId)
+    const merged = (existing?.quantity ?? 0) + local.quantity
+    const clamped = Math.min(merged, stock)
+    if (clamped <= 0) continue
+
+    if (existing) {
+      await prisma.cartItem.update({
+        where: { id: existing.id },
+        data: { quantity: clamped },
+      })
+    } else {
+      await prisma.cartItem.create({
+        data: { cartId: cart.id, productId: local.productId, quantity: clamped },
+      })
+    }
+  }
+}


### PR DESCRIPTION
Closes #119

## 概要
- カート情報をDBに永続化し、ログイン時にローカル（ゲスト）カートをサーバーカートにマージする機能を実装

## 変更内容
- `src/lib/cartMerge.ts`: `computeMergedCart` 純粋関数（在庫上限クランプ・合算・除外ロジック）
- `src/lib/db/carts.ts`: getOrCreateCart / addCartItem / updateCartItemQuantity / removeCartItem / clearCart / mergeLocalCart
- `src/app/api/cart/route.ts`: GET/POST/PATCH/DELETE/PUT(merge) の認証必須API（CART_OPERATION レートリミット適用）
- `src/hooks/useCartMergeOnLogin.ts` + `CartMergeOnLogin` コンポーネント: ログイン直後に1回だけローカルカートをサーバーへマージしクリア
- `src/app/(shop)/layout.tsx`: `CartMergeOnLogin` をマウント

## テスト
- `src/lib/cartMerge.test.ts`: 7 ケース（サーバーのみ／ローカルのみ／合算／在庫クランプ／除外／quantity≤0／複数商品）
- 132/132 tests passing
- tsc / lint / build いずれもクリーン