### PR TITLE
feat(admin): 操作監査ログ（AuditLog）を実装 (#121)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,8 +66,40 @@ model User {
   wishlist                Wishlist?
   stockMovements          StockMovement[] // 追加 (#106)
   emailVerificationTokens EmailVerificationToken[] // 追加 (#120)
+  auditLogs               AuditLog[] // 追加 (#121)
 
   @@map("users")
+}
+
+// 追加 (#121): 管理操作の監査ログ
+enum AuditAction {
+  PRODUCT_CREATE
+  PRODUCT_UPDATE
+  PRODUCT_DELETE
+  STOCK_ADJUST
+  SALE_CREATE
+  SALE_UPDATE
+  SALE_DELETE
+  ORDER_STATUS_CHANGE
+  USER_ROLE_CHANGE
+}
+
+model AuditLog {
+  id         String      @id @default(cuid())
+  actorId    String
+  action     AuditAction
+  targetType String
+  targetId   String
+  metadata   Json?
+  createdAt  DateTime    @default(now())
+
+  actor User @relation(fields: [actorId], references: [id], onDelete: Cascade)
+
+  @@index([actorId])
+  @@index([action])
+  @@index([targetType, targetId])
+  @@index([createdAt])
+  @@map("audit_logs")
 }
 
 // 追加 (#120): メールアドレス確認トークン

--- a/src/app/(admin)/admin/audit-logs/page.tsx
+++ b/src/app/(admin)/admin/audit-logs/page.tsx
@@ -1,0 +1,204 @@
+// 管理画面 監査ログ一覧ページ（#121）
+import { redirect } from 'next/navigation'
+import { AUDIT_ACTIONS, type AuditActionLabel } from '@/constants/audit'
+import { auth } from '@/lib/auth'
+import type { AuditAction } from '@/generated/prisma/enums'
+import { findAuditLogs } from '@/lib/db/auditLogs'
+
+export const metadata = {
+  title: '監査ログ | 管理画面',
+}
+
+type SearchParams = Promise<{
+  action?: string
+  targetType?: string
+  from?: string
+  to?: string
+  page?: string
+}>
+
+const PAGE_SIZE = 50
+
+export default async function AdminAuditLogsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const session = await auth()
+  if (!session?.user || session.user.role !== 'ADMIN') {
+    redirect('/login')
+  }
+
+  const sp = await searchParams
+  const page = Math.max(1, Number(sp.page ?? '1'))
+  const action =
+    sp.action && (AUDIT_ACTIONS as readonly string[]).includes(sp.action)
+      ? (sp.action as AuditAction)
+      : undefined
+  const fromDate = sp.from ? new Date(sp.from) : undefined
+  const toDate = sp.to ? new Date(sp.to) : undefined
+
+  const { logs, total } = await findAuditLogs({
+    action,
+    targetType: sp.targetType || undefined,
+    fromDate: fromDate && !Number.isNaN(fromDate.getTime()) ? fromDate : undefined,
+    toDate: toDate && !Number.isNaN(toDate.getTime()) ? toDate : undefined,
+    take: PAGE_SIZE,
+    skip: (page - 1) * PAGE_SIZE,
+  })
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">監査ログ</h1>
+        <p className="text-sm text-muted-foreground">
+          管理画面で実行された操作の履歴を確認できます。
+        </p>
+      </div>
+
+      <form className="flex flex-wrap gap-3 rounded border p-4" method="get">
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 text-muted-foreground">アクション</span>
+          <select
+            name="action"
+            defaultValue={sp.action ?? ''}
+            className="rounded border px-2 py-1"
+          >
+            <option value="">すべて</option>
+            {AUDIT_ACTIONS.map((a) => (
+              <option key={a} value={a}>
+                {AUDIT_ACTION_LABELS[a]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 text-muted-foreground">対象タイプ</span>
+          <input
+            type="text"
+            name="targetType"
+            defaultValue={sp.targetType ?? ''}
+            placeholder="Product / Order / ..."
+            className="rounded border px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 text-muted-foreground">開始日</span>
+          <input
+            type="date"
+            name="from"
+            defaultValue={sp.from ?? ''}
+            className="rounded border px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 text-muted-foreground">終了日</span>
+          <input
+            type="date"
+            name="to"
+            defaultValue={sp.to ?? ''}
+            className="rounded border px-2 py-1"
+          />
+        </label>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            className="rounded bg-primary px-4 py-1 text-sm text-primary-foreground hover:opacity-90"
+          >
+            絞り込む
+          </button>
+        </div>
+      </form>
+
+      <div className="overflow-x-auto rounded border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted">
+            <tr>
+              <th className="px-3 py-2 text-left">日時</th>
+              <th className="px-3 py-2 text-left">操作者</th>
+              <th className="px-3 py-2 text-left">アクション</th>
+              <th className="px-3 py-2 text-left">対象</th>
+              <th className="px-3 py-2 text-left">詳細</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3 py-6 text-center text-muted-foreground">
+                  該当する監査ログはありません
+                </td>
+              </tr>
+            ) : (
+              logs.map((log) => (
+                <tr key={log.id} className="border-t">
+                  <td className="whitespace-nowrap px-3 py-2">
+                    {new Date(log.createdAt).toLocaleString('ja-JP')}
+                  </td>
+                  <td className="px-3 py-2">
+                    {log.actor?.name ?? log.actor?.email ?? log.actorId}
+                  </td>
+                  <td className="px-3 py-2">{AUDIT_ACTION_LABELS[log.action]}</td>
+                  <td className="px-3 py-2">
+                    {log.targetType}: {log.targetId}
+                  </td>
+                  <td className="px-3 py-2">
+                    <pre className="max-w-xs overflow-x-auto text-xs">
+                      {log.metadata ? JSON.stringify(log.metadata, null, 2) : '-'}
+                    </pre>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <span>
+          {total} 件中 {(page - 1) * PAGE_SIZE + 1}-{Math.min(page * PAGE_SIZE, total)} 件
+        </span>
+        <div className="flex gap-2">
+          {page > 1 && (
+            <a
+              className="rounded border px-3 py-1 hover:bg-muted"
+              href={`?${new URLSearchParams({ ...stripPage(sp), page: String(page - 1) }).toString()}`}
+            >
+              前へ
+            </a>
+          )}
+          {page < totalPages && (
+            <a
+              className="rounded border px-3 py-1 hover:bg-muted"
+              href={`?${new URLSearchParams({ ...stripPage(sp), page: String(page + 1) }).toString()}`}
+            >
+              次へ
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const AUDIT_ACTION_LABELS: Record<AuditActionLabel, string> = {
+  PRODUCT_CREATE: '商品作成',
+  PRODUCT_UPDATE: '商品更新',
+  PRODUCT_DELETE: '商品削除',
+  STOCK_ADJUST: '在庫調整',
+  SALE_CREATE: 'セール作成',
+  SALE_UPDATE: 'セール更新',
+  SALE_DELETE: 'セール削除',
+  ORDER_STATUS_CHANGE: '注文ステータス変更',
+  USER_ROLE_CHANGE: 'ユーザーロール変更',
+}
+
+const stripPage = (sp: Record<string, string | undefined>): Record<string, string> => {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(sp)) {
+    if (k === 'page') continue
+    if (v) out[k] = v
+  }
+  return out
+}

--- a/src/app/api/admin/orders/[id]/status/route.ts
+++ b/src/app/api/admin/orders/[id]/status/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { canTransitionOrderStatus } from '@/constants/orders'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import { findOrderById, updateOrderStatusIfMatches } from '@/lib/db/orders'
 import { sendShipmentNotificationEmail } from '@/lib/email/sendShipmentNotification' // 追加
 import { shippingAddressSchema } from '@/lib/validators/order' // 変更: ダブルキャスト解消のため Zod パースを使用
@@ -95,6 +96,15 @@ export const PUT = async (req: NextRequest, { params }: RouteParams) => {
         console.error('[admin/orders/:id/status PUT] shippingAddress パース失敗。メール送信をスキップ:', addressParsed.error.flatten())
       }
     }
+
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.ORDER_STATUS_CHANGE,
+      targetType: 'Order',
+      targetId: id,
+      metadata: { from: existing.status, to: status },
+    })
 
     return NextResponse.json({ order: updated })
   } catch (err) {

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -1,6 +1,7 @@
 // 管理画面 商品更新・削除 API
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, buildDiff, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import { deleteProduct, findProductByIdForAdmin, updateProduct } from '@/lib/db/products'
 import { productSchema } from '@/lib/validators/product'
 // 追加: 在庫が 0→1 以上に増加した際の自動再入荷通知 (#76)
@@ -82,6 +83,18 @@ export const PUT = async (
         images: product.images,
       })
     }
+    // 追加 (#121): 監査ログ記録（変更前後の差分）
+    const diff = buildDiff(
+      { name: existing.name, price: existing.price, stock: existing.stock, isPublished: existing.isPublished },
+      { name: product.name, price: product.price, stock: product.stock, isPublished: product.isPublished },
+    )
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: existing.stock !== product.stock ? AuditAction.STOCK_ADJUST : AuditAction.PRODUCT_UPDATE,
+      targetType: 'Product',
+      targetId: product.id,
+      metadata: { before: diff.before, after: diff.after },
+    })
     return NextResponse.json({ product })
   } catch (err) {
     console.error('[admin/products PUT] エラー:', err)
@@ -107,6 +120,14 @@ export const DELETE = async (
 
   try {
     await deleteProduct(id)
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.PRODUCT_DELETE,
+      targetType: 'Product',
+      targetId: id,
+      metadata: { name: existing.name },
+    })
     return NextResponse.json({ message: '商品を削除しました' })
   } catch (err) {
     console.error('[admin/products DELETE] エラー:', err)

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -1,6 +1,7 @@
 // 管理画面 商品一覧・作成 API
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import { findAllCategories } from '@/lib/db/categories'
 import { createProduct, findAllProductsForAdmin } from '@/lib/db/products'
 import { productSchema } from '@/lib/validators/product'
@@ -53,6 +54,14 @@ export const POST = async (req: NextRequest) => {
       images,
       ...(lowStockThreshold !== undefined ? { lowStockThreshold } : {}),
       ...(categoryId ? { category: { connect: { id: categoryId } } } : {}),
+    })
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.PRODUCT_CREATE,
+      targetType: 'Product',
+      targetId: product.id,
+      metadata: { name, price, stock, categoryId, isPublished },
     })
     return NextResponse.json({ product }, { status: 201 })
   } catch (err) {

--- a/src/app/api/admin/sales/[id]/route.ts
+++ b/src/app/api/admin/sales/[id]/route.ts
@@ -1,6 +1,7 @@
 // 追加 (#107): タイムセール管理 API（更新・削除）
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import {
   deleteSale,
   findOverlappingSale,
@@ -63,6 +64,14 @@ export const PUT = async (
     }
 
     const sale = await updateSale(id, { salePrice, startsAt, endsAt, isActive })
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.SALE_UPDATE,
+      targetType: 'Sale',
+      targetId: id,
+      metadata: { salePrice, startsAt, endsAt, isActive },
+    })
     return NextResponse.json({ sale })
   } catch (err) {
     console.error('[admin/sales PUT] エラー:', err)
@@ -84,6 +93,13 @@ export const DELETE = async (
   const { id } = await params
   try {
     await deleteSale(id)
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.SALE_DELETE,
+      targetType: 'Sale',
+      targetId: id,
+    })
     return NextResponse.json({ success: true })
   } catch (err) {
     console.error('[admin/sales DELETE] エラー:', err)

--- a/src/app/api/admin/sales/route.ts
+++ b/src/app/api/admin/sales/route.ts
@@ -1,6 +1,7 @@
 // 追加 (#107): タイムセール管理 API（一覧・作成）
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import {
   createSale,
   findAllSales,
@@ -66,6 +67,14 @@ export const POST = async (req: NextRequest) => {
     }
 
     const sale = await createSale({ productId, salePrice, startsAt, endsAt, isActive })
+    // 追加 (#121): 監査ログ記録
+    await recordAuditLog({
+      actorId: check.session.user.id,
+      action: AuditAction.SALE_CREATE,
+      targetType: 'Sale',
+      targetId: sale.id,
+      metadata: { productId, salePrice, startsAt, endsAt, isActive },
+    })
     return NextResponse.json({ sale }, { status: 201 })
   } catch (err) {
     console.error('[admin/sales POST] エラー:', err)

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireAdmin } from '@/lib/admin-auth'
+import { AuditAction, recordAuditLog } from '@/lib/audit' // 追加 (#121)
 import {
   findUserById,
   updateUserRole,
@@ -87,6 +88,16 @@ export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
   try {
     if (role !== undefined) {
       await updateUserRole(id, role)
+      // 追加 (#121): 監査ログ記録（ロール変更）
+      if (existing.role !== role) {
+        await recordAuditLog({
+          actorId: check.session.user.id,
+          action: AuditAction.USER_ROLE_CHANGE,
+          targetType: 'User',
+          targetId: id,
+          metadata: { from: existing.role, to: role },
+        })
+      }
     }
     if (isActive !== undefined) {
       await updateUserActiveStatus(id, isActive)

--- a/src/constants/audit.ts
+++ b/src/constants/audit.ts
@@ -1,0 +1,14 @@
+// 監査ログ関連の定数（#121）
+export const AUDIT_ACTIONS = [
+  'PRODUCT_CREATE',
+  'PRODUCT_UPDATE',
+  'PRODUCT_DELETE',
+  'STOCK_ADJUST',
+  'SALE_CREATE',
+  'SALE_UPDATE',
+  'SALE_DELETE',
+  'ORDER_STATUS_CHANGE',
+  'USER_ROLE_CHANGE',
+] as const
+
+export type AuditActionLabel = (typeof AUDIT_ACTIONS)[number]

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -1,0 +1,32 @@
+// buildDiff の単体テスト（#121）
+import { describe, it, expect } from 'vitest'
+import { buildDiff } from '@/lib/audit'
+
+describe('buildDiff', () => {
+  it('変更されたフィールドのみを抽出する', () => {
+    const result = buildDiff(
+      { name: 'A', price: 100, stock: 5 },
+      { name: 'B', price: 100, stock: 3 },
+    )
+    expect(result.before).toEqual({ name: 'A', stock: 5 })
+    expect(result.after).toEqual({ name: 'B', stock: 3 })
+  })
+
+  it('追加されたフィールドは after にのみ含まれる', () => {
+    const result = buildDiff({ name: 'A' }, { name: 'A', description: 'X' })
+    expect(result.before).toEqual({})
+    expect(result.after).toEqual({ description: 'X' })
+  })
+
+  it('before が null の場合は after の全フィールドを返す', () => {
+    const result = buildDiff(null, { name: 'A', price: 100 })
+    expect(result.before).toEqual({})
+    expect(result.after).toEqual({ name: 'A', price: 100 })
+  })
+
+  it('変更がない場合は空オブジェクトを返す', () => {
+    const result = buildDiff({ name: 'A' }, { name: 'A' })
+    expect(result.before).toEqual({})
+    expect(result.after).toEqual({})
+  })
+})

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,57 @@
+// 管理操作の監査ログ記録（#121）
+import 'server-only'
+import type { Prisma } from '@/generated/prisma/client'
+import { AuditAction } from '@/generated/prisma/enums'
+import { prisma } from '@/lib/db/prisma'
+
+export { AuditAction }
+
+type RecordAuditLogInput = {
+  actorId: string
+  action: AuditAction
+  targetType: string
+  targetId: string
+  metadata?: Record<string, unknown>
+  // トランザクション内で記録する場合に渡す
+  tx?: Prisma.TransactionClient
+}
+
+// 監査ログを記録する。tx を渡すと同一トランザクション内で記録できる
+export const recordAuditLog = async ({
+  actorId,
+  action,
+  targetType,
+  targetId,
+  metadata,
+  tx,
+}: RecordAuditLogInput) => {
+  const client = tx ?? prisma
+  await client.auditLog.create({
+    data: {
+      actorId,
+      action,
+      targetType,
+      targetId,
+      metadata: metadata ? (metadata as Prisma.InputJsonValue) : undefined,
+    },
+  })
+}
+
+// 変更前後の差分を取り、変化したフィールドのみを返すヘルパー
+export const buildDiff = (
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown>,
+): { before: Record<string, unknown>; after: Record<string, unknown> } => {
+  const diffBefore: Record<string, unknown> = {}
+  const diffAfter: Record<string, unknown> = {}
+  const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after)])
+  for (const key of keys) {
+    const b = before?.[key]
+    const a = after[key]
+    if (JSON.stringify(b) !== JSON.stringify(a)) {
+      if (b !== undefined) diffBefore[key] = b
+      diffAfter[key] = a
+    }
+  }
+  return { before: diffBefore, after: diffAfter }
+}

--- a/src/lib/db/auditLogs.ts
+++ b/src/lib/db/auditLogs.ts
@@ -1,0 +1,47 @@
+// 監査ログ取得（#121）
+import 'server-only'
+import type { Prisma } from '@/generated/prisma/client'
+import type { AuditAction } from '@/generated/prisma/enums'
+import { prisma } from '@/lib/db/prisma'
+
+type FindAuditLogsParams = {
+  action?: AuditAction
+  targetType?: string
+  actorId?: string
+  fromDate?: Date
+  toDate?: Date
+  take?: number
+  skip?: number
+}
+
+export const findAuditLogs = async ({
+  action,
+  targetType,
+  actorId,
+  fromDate,
+  toDate,
+  take = 50,
+  skip = 0,
+}: FindAuditLogsParams) => {
+  const where: Prisma.AuditLogWhereInput = {}
+  if (action) where.action = action
+  if (targetType) where.targetType = targetType
+  if (actorId) where.actorId = actorId
+  if (fromDate || toDate) {
+    where.createdAt = {
+      ...(fromDate ? { gte: fromDate } : {}),
+      ...(toDate ? { lte: toDate } : {}),
+    }
+  }
+  const [logs, total] = await Promise.all([
+    prisma.auditLog.findMany({
+      where,
+      include: { actor: { select: { id: true, email: true, name: true } } },
+      orderBy: { createdAt: 'desc' },
+      take,
+      skip,
+    }),
+    prisma.auditLog.count({ where }),
+  ])
+  return { logs, total }
+}


### PR DESCRIPTION
Closes #121

## 概要
管理画面の重要操作を AuditLog に記録し、管理者が一覧で閲覧できるようにした。

## 変更内容
- prisma: `AuditAction` enum + `AuditLog` モデル追加（actorId/action/targetType/targetId/metadata Json/createdAt + 各種index）
- `src/lib/audit.ts`: `recordAuditLog()`（tx 受け取り対応）と `buildDiff()`
- `src/lib/db/auditLogs.ts`: フィルター付きの `findAuditLogs()`
- 各管理 API ルートで recordAuditLog を呼び出し:
  - 商品 CRUD（PRODUCT_CREATE/UPDATE/DELETE、stock 変化時は STOCK_ADJUST）
  - セール CRUD（SALE_CREATE/UPDATE/DELETE）
  - 注文ステータス変更（ORDER_STATUS_CHANGE）
  - ユーザーロール変更（USER_ROLE_CHANGE）
- `/admin/audit-logs` 一覧ページ（アクション・対象タイプ・期間で絞り込み・ページネーション）

## テスト
- `src/lib/audit.test.ts`: `buildDiff` 4 ケース
- 136/136 tests passing
- tsc / lint / build いずれもクリーン