### PR TITLE
chore(security): セキュリティヘッダー強化 (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ npm run build
 npm run start
 ```
 
+## セキュリティポリシー
+
+### セキュリティヘッダー（#122）
+全ルートに以下のヘッダーを `next.config.mjs` で付与している。
+
+| ヘッダー | 値 | 目的 |
+|---|---|---|
+| `Content-Security-Policy` | `default-src 'self'` ベース。Stripe・Cloudinary・Sentry・Resend を許可 | XSS / データインジェクション防止 |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | HTTPS 強制 |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラー漏洩防止 |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 不要な権限 API を全拒否 |
+| `X-Content-Type-Options` | `nosniff` | MIME スニッフィング防止 |
+| `X-Frame-Options` | `DENY` | クリックジャッキング防止 |
+
+CSP の `script-src` には Next.js のインライン runtime と Stripe.js のため `'unsafe-inline'` `'unsafe-eval'` を許容している。将来的には nonce 方式への移行を検討する。
+
+### 脆弱性スキャン
+CI では `pnpm audit --audit-level=critical --prod` で critical のみ fail、high は警告表示で継続する。
+
 ## ライセンス
 
 <!-- TODO: ライセンスを記載してください -->

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,43 @@
 /** @type {import('next').NextConfig} */
+
+// 追加 (#122): セキュリティヘッダー
+// Stripe / Cloudinary / Sentry / Resend / Google OAuth と整合する CSP を構築する
+const cspDirectives = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  // Stripe iframe を許可
+  "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+  // Stripe.js / Sentry のクライアント SDK / Next.js のインライン runtime
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://*.sentry.io",
+  // Tailwind は外部 CSS を必要としないが Next.js が一部 inline を使うため許容
+  "style-src 'self' 'unsafe-inline'",
+  // Cloudinary 画像と data: / blob: を許可
+  "img-src 'self' data: blob: https://res.cloudinary.com",
+  "font-src 'self' data:",
+  // Stripe API / Sentry / Resend / 自身の API
+  "connect-src 'self' https://api.stripe.com https://*.ingest.sentry.io https://*.sentry.io https://api.resend.com",
+  "object-src 'none'",
+  "media-src 'self'",
+  'upgrade-insecure-requests',
+].join('; ')
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: cspDirectives },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+]
+
 const baseConfig = {
   images: {
     // 追加 (#109): AVIF / WebP を優先配信して画像転送量を削減
@@ -15,6 +54,15 @@ const baseConfig = {
   // 追加 (#109): バレルファイルを最適化してクライアントバンドルを縮小
   experimental: {
     optimizePackageImports: ['lucide-react'],
+  },
+  // 追加 (#122): セキュリティヘッダーを全パスに付与
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
   },
 };
 


### PR DESCRIPTION
Closes #122

## 概要
全パスにセキュリティヘッダーを付与し、CSP で Stripe / Cloudinary / Sentry / Resend を許可した。

## 変更内容
- `next.config.mjs`: `headers()` を追加して以下を全パスに付与
  - Content-Security-Policy（Stripe/Cloudinary/Sentry/Resend 許可、frame-ancestors 'none'）
  - Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
  - Referrer-Policy: strict-origin-when-cross-origin
  - Permissions-Policy: camera=(), microphone=(), geolocation=()
  - X-Content-Type-Options: nosniff
  - X-Frame-Options: DENY
- README にセキュリティポリシーを追記

## 補足
- CI の pnpm audit ステップは既に整備済み（#75）
- pnpm audit --prod: high/critical 0、moderate 3（既知）
- build / tsc / lint いずれもクリーン