### PR TITLE
feat(auth): パスワードリセット機能 (#129)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model User {
   stockMovements          StockMovement[] // 追加 (#106)
   emailVerificationTokens EmailVerificationToken[] // 追加 (#120)
   auditLogs               AuditLog[] // 追加 (#121)
+  passwordResetTokens     PasswordResetToken[] // 追加 (#129)
 
   @@map("users")
 }
@@ -114,6 +115,21 @@ model EmailVerificationToken {
 
   @@index([userId])
   @@map("email_verification_tokens")
+}
+
+// 追加 (#129): パスワードリセットトークン
+model PasswordResetToken {
+  id          String    @id @default(cuid())
+  userId      String
+  token       String    @unique
+  expiresAt   DateTime
+  consumedAt  DateTime?
+  createdAt   DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("password_reset_tokens")
 }
 
 // ----- カテゴリ -----

--- a/src/app/(shop)/forgot-password/page.tsx
+++ b/src/app/(shop)/forgot-password/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ForgotPasswordForm } from '@/components/features/auth/ForgotPasswordForm'
+import { AUTH_ROUTES } from '@/constants/auth'
+
+export const metadata: Metadata = {
+  title: 'パスワードをお忘れの方',
+  description: 'パスワードリセット用のメールを送信します',
+}
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-md flex-col justify-center px-4 py-12">
+      <div className="rounded-lg border bg-card p-8 shadow-sm">
+        <h1 className="mb-2 text-center text-2xl font-bold tracking-tight">
+          パスワードをお忘れの方
+        </h1>
+        <p className="mb-6 text-center text-sm text-muted-foreground">
+          ご登録のメールアドレスを入力してください。リセット用のリンクをお送りします。
+        </p>
+        <ForgotPasswordForm />
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          <Link
+            href={AUTH_ROUTES.LOGIN}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            ログインに戻る
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(shop)/login/page.tsx
+++ b/src/app/(shop)/login/page.tsx
@@ -38,6 +38,15 @@ export default function LoginPage() {
             会員登録
           </Link>
         </p>
+        {/* 追加 (#129): パスワードリセットへのリンク */}
+        <p className="mt-2 text-center text-sm text-muted-foreground">
+          <Link
+            href={AUTH_ROUTES.FORGOT_PASSWORD}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            パスワードをお忘れの方
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/src/app/(shop)/reset-password/page.tsx
+++ b/src/app/(shop)/reset-password/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ResetPasswordForm } from '@/components/features/auth/ResetPasswordForm'
+import { AUTH_ROUTES } from '@/constants/auth'
+
+export const metadata: Metadata = {
+  title: 'パスワード再設定',
+  description: '新しいパスワードを設定します',
+}
+
+type Props = {
+  searchParams: Promise<{ token?: string }>
+}
+
+export default async function ResetPasswordPage({ searchParams }: Props) {
+  const { token } = await searchParams
+  const safeToken = typeof token === 'string' ? token : ''
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-md flex-col justify-center px-4 py-12">
+      <div className="rounded-lg border bg-card p-8 shadow-sm">
+        <h1 className="mb-2 text-center text-2xl font-bold tracking-tight">パスワード再設定</h1>
+        {safeToken ? (
+          <>
+            <p className="mb-6 text-center text-sm text-muted-foreground">
+              新しいパスワードを入力してください。
+            </p>
+            <ResetPasswordForm token={safeToken} />
+          </>
+        ) : (
+          <>
+            <p className="mb-6 text-center text-sm text-destructive">
+              リンクが無効です。再度パスワードリセットを依頼してください。
+            </p>
+            <p className="text-center text-sm">
+              <Link
+                href={AUTH_ROUTES.FORGOT_PASSWORD}
+                className="font-medium text-primary underline-offset-4 hover:underline"
+              >
+                パスワードリセットページへ
+              </Link>
+            </p>
+          </>
+        )}
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          <Link
+            href={AUTH_ROUTES.LOGIN}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+          >
+            ログインに戻る
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,55 @@
+// パスワードリセット要求 API（#129）
+import { NextRequest, NextResponse } from 'next/server'
+import { findUserByEmail } from '@/lib/db/users'
+import { issuePasswordResetToken } from '@/lib/db/passwordResetTokens'
+import { sendPasswordResetEmail } from '@/lib/email/sendPasswordReset'
+import { forgotPasswordSchema } from '@/lib/validators/auth'
+import { enforceRateLimit } from '@/lib/rateLimit'
+
+export const POST = async (req: NextRequest) => {
+  // ブルートフォース対策: 5分に1回（IP単位）
+  const limited = enforceRateLimit('PASSWORD_RESET_REQUEST', req)
+  if (limited) return limited
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = forgotPasswordSchema.safeParse(body)
+    if (!parsed.success) {
+      // メール列挙対策: バリデーション失敗時も同じ成功レスポンスを返す
+      return NextResponse.json(
+        { message: 'リクエストを受け付けました。該当のメールアドレスにご案内を送信します。' },
+        { status: 200 },
+      )
+    }
+    const { email } = parsed.data
+
+    // ユーザーが存在する場合のみトークン発行＆メール送信。失敗してもクライアントには成功レスポンス
+    const user = await findUserByEmail(email)
+    if (user && user.isActive !== false) {
+      try {
+        const { token } = await issuePasswordResetToken(user.id)
+        const resetUrl = `${req.nextUrl.origin}/reset-password?token=${encodeURIComponent(token)}`
+        await sendPasswordResetEmail({
+          to: email,
+          templateParams: {
+            customerName: user.name ?? 'お客様',
+            resetUrl,
+          },
+        })
+      } catch (err) {
+        console.error('[forgot-password] トークン発行/メール送信失敗:', err)
+      }
+    }
+
+    // メールアドレス列挙を防ぐため、結果に関わらず常に同じレスポンス
+    return NextResponse.json(
+      { message: 'リクエストを受け付けました。該当のメールアドレスにご案内を送信します。' },
+      { status: 200 },
+    )
+  } catch {
+    return NextResponse.json(
+      { error: 'サーバーエラーが発生しました', code: 'INTERNAL_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,45 @@
+// パスワード再設定 API（#129）
+import { NextRequest, NextResponse } from 'next/server'
+import { consumePasswordResetToken } from '@/lib/db/passwordResetTokens'
+import { resetPasswordSchema } from '@/lib/validators/auth'
+import { enforceRateLimit } from '@/lib/rateLimit'
+
+export const POST = async (req: NextRequest) => {
+  // ブルートフォース対策: IP 単位で 1分10回まで
+  const limited = enforceRateLimit('PASSWORD_RESET_CONSUME', req)
+  if (limited) return limited
+
+  try {
+    const body: unknown = await req.json()
+    const parsed = resetPasswordSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '入力内容が正しくありません', code: 'VALIDATION_ERROR' },
+        { status: 400 },
+      )
+    }
+    const { token, password } = parsed.data
+
+    const result = await consumePasswordResetToken(token, password)
+    if (!result.ok) {
+      // 全ての失敗を「無効なリンクです」に統一（情報漏洩を防ぐ）
+      return NextResponse.json(
+        {
+          error: 'リンクが無効か、有効期限が切れています。再度リセットを依頼してください。',
+          code: 'INVALID_TOKEN',
+        },
+        { status: 400 },
+      )
+    }
+
+    return NextResponse.json(
+      { message: 'パスワードを更新しました。新しいパスワードでログインしてください。' },
+      { status: 200 },
+    )
+  } catch {
+    return NextResponse.json(
+      { error: 'サーバーエラーが発生しました', code: 'INTERNAL_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/auth/ForgotPasswordForm.tsx
+++ b/src/components/features/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+// パスワードリセット要求フォーム（#129）
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  forgotPasswordSchema,
+  type ForgotPasswordFormValues,
+} from '@/lib/validators/auth'
+
+export const ForgotPasswordForm = () => {
+  const [success, setSuccess] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+  })
+
+  const onSubmit = async (data: ForgotPasswordFormValues) => {
+    setServerError(null)
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) {
+        // レート制限などの失敗
+        const json = (await res.json().catch(() => ({}))) as { error?: string }
+        setServerError(json.error ?? 'リクエストに失敗しました')
+        return
+      }
+      setSuccess(true)
+    } catch {
+      setServerError('通信エラーが発生しました')
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-3" role="status" aria-live="polite">
+        <p className="text-sm">
+          リクエストを受け付けました。ご登録のメールアドレス宛にリセット用のリンクを送信しました。
+          メールをご確認ください。
+        </p>
+        <p className="text-xs text-muted-foreground">
+          メールが届かない場合は、迷惑メールフォルダもご確認ください。
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="email">メールアドレス</Label>
+        <Input
+          id="email"
+          type="email"
+          autoComplete="email"
+          aria-describedby={errors.email ? 'email-error' : undefined}
+          {...register('email')}
+        />
+        {errors.email && (
+          <p id="email-error" className="text-sm text-destructive" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="text-sm text-destructive" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        {isSubmitting ? '送信中...' : 'リセットリンクを送信'}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/features/auth/ResetPasswordForm.tsx
+++ b/src/components/features/auth/ResetPasswordForm.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+// パスワード再設定フォーム（#129）
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  resetPasswordSchema,
+  type ResetPasswordFormValues,
+} from '@/lib/validators/auth'
+import { AUTH_ROUTES } from '@/constants/auth'
+
+type Props = {
+  token: string
+}
+
+export const ResetPasswordForm = ({ token }: Props) => {
+  const router = useRouter()
+  const [success, setSuccess] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { token, password: '' },
+  })
+
+  const onSubmit = async (data: ResetPasswordFormValues) => {
+    setServerError(null)
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string }
+        setServerError(json.error ?? 'パスワードのリセットに失敗しました')
+        return
+      }
+      setSuccess(true)
+      // 3秒後にログイン画面へ
+      setTimeout(() => {
+        router.push(AUTH_ROUTES.LOGIN)
+      }, 2000)
+    } catch {
+      setServerError('通信エラーが発生しました')
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-3" role="status" aria-live="polite">
+        <p className="text-sm">
+          パスワードを更新しました。新しいパスワードでログインしてください。
+        </p>
+        <p className="text-xs text-muted-foreground">まもなくログイン画面に移動します...</p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+      <input type="hidden" {...register('token')} />
+
+      <div className="space-y-2">
+        <Label htmlFor="password">新しいパスワード</Label>
+        <Input
+          id="password"
+          type="password"
+          autoComplete="new-password"
+          aria-describedby={errors.password ? 'password-error' : undefined}
+          {...register('password')}
+        />
+        {errors.password && (
+          <p id="password-error" className="text-sm text-destructive" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      {serverError && (
+        <p className="text-sm text-destructive" role="alert">
+          {serverError}
+        </p>
+      )}
+
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        {isSubmitting ? '更新中...' : 'パスワードを更新'}
+      </Button>
+    </form>
+  )
+}

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -7,5 +7,7 @@ export const BCRYPT_SALT_ROUNDS = 12
 export const AUTH_ROUTES = {
   LOGIN: '/login',
   REGISTER: '/register',
+  FORGOT_PASSWORD: '/forgot-password', // 追加 (#129)
+  RESET_PASSWORD: '/reset-password', // 追加 (#129)
   DEFAULT_REDIRECT: '/',
 } as const

--- a/src/constants/email.ts
+++ b/src/constants/email.ts
@@ -8,6 +8,7 @@ export const EMAIL_SUBJECTS = {
   BACK_IN_STOCK: '商品が再入荷しました', // 追加: バックインストック通知
   REFUND_NOTIFICATION: '返金が完了しました', // 追加 (#117)
   EMAIL_VERIFICATION: 'メールアドレスを確認してください', // 追加 (#120)
+  PASSWORD_RESET: 'パスワードリセットのご案内', // 追加 (#129)
 } as const
 
 // 追加: メール通知テンプレートのキー（Prisma enum と一致）

--- a/src/constants/passwordReset.ts
+++ b/src/constants/passwordReset.ts
@@ -1,0 +1,5 @@
+// 追加 (#129): パスワードリセット関連の定数
+export const PASSWORD_RESET_TOKEN_TTL_HOURS = 24
+export const PASSWORD_RESET_TOKEN_TTL_MS =
+  PASSWORD_RESET_TOKEN_TTL_HOURS * 60 * 60 * 1000
+export const PASSWORD_RESET_TOKEN_BYTES = 32

--- a/src/constants/rateLimit.ts
+++ b/src/constants/rateLimit.ts
@@ -19,6 +19,10 @@ export const RATE_LIMITS = {
   EMAIL_VERIFY_RESEND: 1,
   // 追加 (#119): カート操作（API）
   CART_OPERATION: 60,
+  // 追加 (#129): パスワードリセット要求（5分に1回）
+  PASSWORD_RESET_REQUEST: 1,
+  // 追加 (#129): パスワードリセット実行（IP 単位、ブルートフォース対策）
+  PASSWORD_RESET_CONSUME: 10,
 } as const
 
 export type RateLimitKey = keyof typeof RATE_LIMITS
@@ -26,6 +30,7 @@ export type RateLimitKey = keyof typeof RATE_LIMITS
 // 追加 (#120): キーごとに異なるウィンドウを使用したい場合の上書き定義
 export const RATE_LIMIT_WINDOW_OVERRIDES: Partial<Record<RateLimitKey, number>> = {
   EMAIL_VERIFY_RESEND: 5 * 60 * 1000, // 5分
+  PASSWORD_RESET_REQUEST: 5 * 60 * 1000, // 5分（#129）
 }
 
 // レート制限超過時のエラーコード

--- a/src/lib/db/passwordResetTokens.ts
+++ b/src/lib/db/passwordResetTokens.ts
@@ -1,0 +1,56 @@
+// パスワードリセットトークン関連の DB 操作（#129）
+import { randomBytes } from 'crypto'
+import bcrypt from 'bcryptjs'
+import { BCRYPT_SALT_ROUNDS } from '@/constants/auth'
+import {
+  PASSWORD_RESET_TOKEN_BYTES,
+  PASSWORD_RESET_TOKEN_TTL_MS,
+} from '@/constants/passwordReset'
+import { prisma } from '@/lib/db/prisma'
+
+// 新しいリセットトークンを発行（既存の未消費トークンは無効化）
+export const issuePasswordResetToken = async (userId: string) => {
+  // 既存の未消費トークンを削除（古いリンクが使えないように）
+  await prisma.passwordResetToken.deleteMany({
+    where: { userId, consumedAt: null },
+  })
+
+  const token = randomBytes(PASSWORD_RESET_TOKEN_BYTES).toString('hex')
+  const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_TTL_MS)
+  await prisma.passwordResetToken.create({
+    data: { userId, token, expiresAt },
+  })
+  return { token, expiresAt }
+}
+
+// トークン検証 + パスワード更新（成功時 token は consumed に）
+export const consumePasswordResetToken = async (
+  token: string,
+  newPassword: string,
+): Promise<
+  { ok: true; userId: string } | { ok: false; reason: 'NOT_FOUND' | 'EXPIRED' | 'CONSUMED' }
+> => {
+  const record = await prisma.passwordResetToken.findUnique({ where: { token } })
+  if (!record) return { ok: false, reason: 'NOT_FOUND' }
+  if (record.consumedAt) return { ok: false, reason: 'CONSUMED' }
+  if (record.expiresAt < new Date()) {
+    return { ok: false, reason: 'EXPIRED' }
+  }
+  const passwordHash = await bcrypt.hash(newPassword, BCRYPT_SALT_ROUNDS)
+  // トランザクションで原子的に更新
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: record.userId },
+      data: { passwordHash },
+    }),
+    prisma.passwordResetToken.update({
+      where: { id: record.id },
+      data: { consumedAt: new Date() },
+    }),
+    // 同ユーザーの他の未消費トークンも無効化
+    prisma.passwordResetToken.deleteMany({
+      where: { userId: record.userId, consumedAt: null, NOT: { id: record.id } },
+    }),
+  ])
+  return { ok: true, userId: record.userId }
+}

--- a/src/lib/email/sendPasswordReset.ts
+++ b/src/lib/email/sendPasswordReset.ts
@@ -1,0 +1,32 @@
+// パスワードリセットメール送信（#129）
+import 'server-only'
+import { resend } from '@/lib/email/client'
+import { env } from '@/env'
+import { EMAIL_SUBJECTS } from '@/constants/email'
+import {
+  renderPasswordResetHtml,
+  type PasswordResetParams,
+} from '@/lib/email/templates/passwordReset'
+
+type SendResult = { success: boolean; error?: string }
+
+export const sendPasswordResetEmail = async (params: {
+  to: string
+  templateParams: PasswordResetParams
+}): Promise<SendResult> => {
+  const { to, templateParams } = params
+  try {
+    const html = renderPasswordResetHtml(templateParams)
+    await resend.emails.send({
+      from: env.EMAIL_FROM,
+      to,
+      subject: EMAIL_SUBJECTS.PASSWORD_RESET,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '不明なエラー'
+    console.error('[sendPasswordResetEmail] 送信失敗:', err)
+    return { success: false, error: message }
+  }
+}

--- a/src/lib/email/templates/passwordReset.ts
+++ b/src/lib/email/templates/passwordReset.ts
@@ -1,0 +1,32 @@
+// パスワードリセットメール テンプレート（#129）
+import { escapeHtml } from '@/lib/email/utils'
+
+export type PasswordResetParams = {
+  customerName: string
+  resetUrl: string
+}
+
+export const renderPasswordResetHtml = (params: PasswordResetParams): string => {
+  const { customerName, resetUrl } = params
+  const safeUrl = escapeHtml(resetUrl)
+  return `<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827;background-color:#f9fafb;margin:0;padding:24px;">
+    <div style="max-width:600px;margin:0 auto;background-color:#ffffff;padding:32px;border-radius:8px;">
+      <h1 style="font-size:20px;margin:0 0 16px;">パスワードリセットのご案内</h1>
+      <p style="margin:0 0 16px;">${escapeHtml(customerName)} 様</p>
+      <p style="margin:0 0 16px;">パスワードリセットのリクエストを受け付けました。下記のボタンから新しいパスワードを設定してください。</p>
+      <p style="margin:24px 0;">
+        <a href="${safeUrl}" style="display:inline-block;background-color:#111827;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:6px;font-weight:600;">
+          パスワードを再設定する
+        </a>
+      </p>
+      <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">ボタンが押せない場合は、以下の URL をブラウザに貼り付けてください:</p>
+      <p style="margin:0 0 24px;font-size:12px;color:#6b7280;word-break:break-all;">${safeUrl}</p>
+      <p style="margin:0 0 16px;color:#6b7280;font-size:14px;">※ このリンクは 24 時間有効です。リンクは 1 度のみ使用できます。</p>
+      <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;"/>
+      <p style="font-size:12px;color:#6b7280;margin:0;">本リクエストに心当たりがない場合は、このメールを破棄してください。アカウントは安全に保たれています。</p>
+    </div>
+  </body>
+</html>`
+}

--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -23,3 +23,19 @@ export const registerSchema = z.object({
 
 export type LoginFormValues = z.infer<typeof loginSchema>
 export type RegisterFormValues = z.infer<typeof registerSchema>
+
+// 追加 (#129): パスワードリセット要求スキーマ
+export const forgotPasswordSchema = z.object({
+  email: z.string().email('有効なメールアドレスを入力してください'),
+})
+export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>
+
+// 追加 (#129): パスワード再設定スキーマ
+export const resetPasswordSchema = z.object({
+  token: z.string().min(1, 'トークンが必要です'),
+  password: z
+    .string()
+    .min(PASSWORD_MIN_LENGTH, `パスワードは${PASSWORD_MIN_LENGTH}文字以上で入力してください`)
+    .max(PASSWORD_MAX_LENGTH, `パスワードは${PASSWORD_MAX_LENGTH}文字以内で入力してください`),
+})
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>

--- a/src/lib/validators/passwordReset.test.ts
+++ b/src/lib/validators/passwordReset.test.ts
@@ -1,0 +1,49 @@
+// パスワードリセットの Zod スキーマテスト（#129）
+import { describe, expect, it } from 'vitest'
+import {
+  forgotPasswordSchema,
+  resetPasswordSchema,
+} from './auth'
+
+describe('forgotPasswordSchema', () => {
+  it('正しいメールアドレスを受理する', () => {
+    const result = forgotPasswordSchema.safeParse({ email: 'user@example.com' })
+    expect(result.success).toBe(true)
+  })
+
+  it('不正なメールアドレスを拒否する', () => {
+    const result = forgotPasswordSchema.safeParse({ email: 'not-email' })
+    expect(result.success).toBe(false)
+  })
+
+  it('email が空の場合は拒否する', () => {
+    const result = forgotPasswordSchema.safeParse({ email: '' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('resetPasswordSchema', () => {
+  it('正しい token と password を受理する', () => {
+    const result = resetPasswordSchema.safeParse({
+      token: 'abc123',
+      password: 'password1234',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('token が空の場合は拒否する', () => {
+    const result = resetPasswordSchema.safeParse({
+      token: '',
+      password: 'password1234',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('password が短すぎる場合は拒否する', () => {
+    const result = resetPasswordSchema.safeParse({
+      token: 'abc',
+      password: 'short',
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #129

## 概要
メール経由のパスワードリセット機能を実装。

## 変更点
- `PasswordResetToken` モデル追加（userId/token@unique/expiresAt/consumedAt）
- API: POST /api/auth/forgot-password（常に200を返しメール列挙を防止、5分/1回 IP rate limit）
- API: POST /api/auth/reset-password（token検証 + bcrypt + consumedAt記録、1分/10回 IP rate limit）
- ページ: /forgot-password, /reset-password?token=...
- メール送信（Resend）+ HTMLテンプレート（escapeHtml済）
- ログイン画面に「パスワードをお忘れの方」リンク追加
- Zod バリデータと単体テスト

## セキュリティ
- メール列挙対策: 該当ユーザー有無に関わらず同一レスポンス
- レート制限: REQUEST 5min/1, CONSUME 1min/10
- トークン: 32 bytes random hex / 24h TTL / 1回使用後consumed
- 失敗理由を統一エラーに集約（NOT_FOUND/EXPIRED/CONSUMED → INVALID_TOKEN）