### PR TITLE
feat(orders): 顧客側の注文キャンセル (#130)

### DIFF
--- a/src/app/api/orders/[id]/cancel/route.ts
+++ b/src/app/api/orders/[id]/cancel/route.ts
@@ -1,0 +1,142 @@
+// 顧客 注文キャンセル API（#130）
+// PENDING/PAID 状態に限り顧客自身がキャンセル可能。
+// PAID の場合は Stripe で全額返金を実行し、REFUNDED に遷移。
+// PENDING の場合は CANCELLED に遷移。在庫は両ケースで復元する。
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { findOrderById } from '@/lib/db/orders'
+import { prisma } from '@/lib/db/prisma'
+import { stripe } from '@/lib/stripe'
+import { recordAuditLog } from '@/lib/audit'
+import { AuditAction } from '@/generated/prisma/enums'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+// POST /api/orders/:id/cancel - 顧客が注文をキャンセル
+export const POST = async (_req: NextRequest, { params }: RouteParams) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  try {
+    const order = await findOrderById(id)
+    if (!order) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    // 本人の注文のみ操作可能
+    if (order.userId !== session.user.id) {
+      return NextResponse.json({ error: '注文が見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+
+    // キャンセル可能ステータス（PENDING/PAID のみ）
+    if (order.status !== 'PENDING' && order.status !== 'PAID') {
+      return NextResponse.json(
+        {
+          error: 'この注文はキャンセルできない状態です（発送済みの場合は返品申請をご利用ください）',
+          code: 'CANNOT_CANCEL',
+        },
+        { status: 403 },
+      )
+    }
+
+    const isPaid = order.status === 'PAID'
+    const newStatus = isPaid ? 'REFUNDED' : 'CANCELLED'
+
+    // Stripe 返金（PAID のみ・トランザクション外で実施）
+    let stripeRefundId: string | null = null
+    if (isPaid) {
+      if (!order.stripePaymentIntentId) {
+        return NextResponse.json(
+          { error: 'Stripe決済情報が見つからないためキャンセルできません', code: 'NO_PAYMENT_INTENT' },
+          { status: 400 },
+        )
+      }
+      try {
+        const refund = await stripe.refunds.create({
+          payment_intent: order.stripePaymentIntentId,
+          amount: order.totalPrice,
+        })
+        stripeRefundId = refund.id
+      } catch (err) {
+        console.error('[orders/:id/cancel] Stripe返金失敗:', err)
+        return NextResponse.json(
+          { error: '返金処理に失敗しました。時間をおいて再度お試しください', code: 'REFUND_FAILED' },
+          { status: 500 },
+        )
+      }
+    }
+
+    // 楽観ロック付きでステータス更新 + 在庫復元 + 監査ログをトランザクションで実施
+    try {
+      await prisma.$transaction(async (tx) => {
+        // ステータス更新（楽観ロック）
+        const result = await tx.order.updateMany({
+          where: { id, status: order.status },
+          data: {
+            status: newStatus,
+            ...(isPaid && stripeRefundId
+              ? {
+                  refundedAmount: order.totalPrice,
+                  refundedAt: new Date(),
+                  stripeRefundId,
+                }
+              : {}),
+          },
+        })
+        if (result.count === 0) {
+          throw new Error('STATUS_CHANGED')
+        }
+
+        // 在庫復元（注文明細の数量を商品在庫に戻す）
+        for (const item of order.items) {
+          await tx.product.update({
+            where: { id: item.productId },
+            data: { stock: { increment: item.quantity } },
+          })
+        }
+
+        // 監査ログ
+        await recordAuditLog({
+          actorId: session.user.id,
+          action: AuditAction.ORDER_STATUS_CHANGE,
+          targetType: 'Order',
+          targetId: id,
+          metadata: {
+            from: order.status,
+            to: newStatus,
+            cancelledByCustomer: true,
+            ...(stripeRefundId ? { stripeRefundId } : {}),
+          },
+          tx,
+        })
+      })
+    } catch (err) {
+      // ステータス競合は 409、それ以外は 500
+      if (err instanceof Error && err.message === 'STATUS_CHANGED') {
+        return NextResponse.json(
+          { error: '他の操作により注文状態が変わりました。再度ご確認ください', code: 'STATUS_CHANGED' },
+          { status: 409 },
+        )
+      }
+      console.error('[orders/:id/cancel] DBトランザクション失敗:', err)
+      return NextResponse.json(
+        { error: 'キャンセル処理に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+        { status: 500 },
+      )
+    }
+
+    const updated = await findOrderById(id)
+    return NextResponse.json({ order: updated, refundId: stripeRefundId })
+  } catch (err) {
+    console.error('[orders/:id/cancel POST] エラー:', err)
+    return NextResponse.json(
+      { error: 'キャンセル処理に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/orders/CancelOrderButton.tsx
+++ b/src/components/features/orders/CancelOrderButton.tsx
@@ -1,0 +1,89 @@
+'use client'
+// 顧客向け 注文キャンセルボタン（#130）
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+type Props = {
+  orderId: string
+  isPaid: boolean
+}
+
+export const CancelOrderButton = ({ orderId, isPaid }: Props) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = () => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/orders/${orderId}/cancel`, {
+          method: 'POST',
+        })
+        if (!res.ok) {
+          const data: unknown = await res.json().catch(() => ({}))
+          const message =
+            data &&
+            typeof data === 'object' &&
+            'error' in data &&
+            typeof (data as { error: unknown }).error === 'string'
+              ? (data as { error: string }).error
+              : 'キャンセル処理に失敗しました'
+          setError(message)
+          return
+        }
+        setOpen(false)
+        router.refresh()
+      } catch {
+        setError('キャンセル処理に失敗しました')
+      }
+    })
+  }
+
+  if (!open) {
+    return (
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        注文をキャンセル
+      </Button>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <p className="text-sm font-medium">注文をキャンセルしますか？</p>
+      <p className="text-xs text-muted-foreground">
+        {isPaid
+          ? 'お支払い済みの注文をキャンセルすると、Stripe を通じて全額返金されます。返金には数営業日かかる場合があります。'
+          : '未決済の注文をキャンセルします。この操作は取り消せません。'}
+      </p>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="destructive"
+          onClick={handleSubmit}
+          disabled={isPending}
+        >
+          {isPending ? 'キャンセル処理中...' : 'はい、キャンセルする'}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            setOpen(false)
+            setError(null)
+          }}
+          disabled={isPending}
+        >
+          戻る
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/orders/OrderDetail.tsx
+++ b/src/components/features/orders/OrderDetail.tsx
@@ -7,6 +7,7 @@ import type { ShippingAddress } from '@/constants/checkout'
 import { OrderStatusBadge } from '@/components/features/orders/OrderStatusBadge'
 import { OrderTimeline } from '@/components/features/orders/OrderTimeline' // 追加 (#118)
 import { ReturnRequestButton } from '@/components/features/orders/ReturnRequestButton' // 追加 (#117)
+import { CancelOrderButton } from '@/components/features/orders/CancelOrderButton' // 追加 (#130)
 
 type OrderItemWithProduct = OrderItem & { product: Product }
 type OrderWithItems = Order & { items: OrderItemWithProduct[] }
@@ -34,6 +35,9 @@ export const OrderDetail = ({ order }: Props) => {
   // 返品申請可能かどうか（#117）: PAID/SHIPPED/DELIVERED のみ
   const canRequestReturn =
     order.status === 'PAID' || order.status === 'SHIPPED' || order.status === 'DELIVERED'
+
+  // 追加 (#130): 顧客側キャンセル可能かどうか - PENDING/PAID のみ
+  const canCancel = order.status === 'PENDING' || order.status === 'PAID'
 
   return (
     <div className="space-y-6">
@@ -179,6 +183,16 @@ export const OrderDetail = ({ order }: Props) => {
             返品申請
           </h2>
           <ReturnRequestButton orderId={order.id} />
+        </section>
+      )}
+
+      {/* 注文キャンセルボタン (#130) */}
+      {canCancel && (
+        <section aria-labelledby="order-cancel-action-heading">
+          <h2 id="order-cancel-action-heading" className="sr-only">
+            注文キャンセル
+          </h2>
+          <CancelOrderButton orderId={order.id} isPaid={order.status === 'PAID'} />
         </section>
       )}
     </div>


### PR DESCRIPTION
Closes #130

## 概要
PENDING / PAID 状態の注文を顧客自身がキャンセルできるようにする。

## 動作
- POST /api/orders/:id/cancel
- 認証必須・本人の注文のみ（404）
- PENDING → CANCELLED（在庫復元のみ）
- PAID → Stripe 全額返金 → REFUNDED（refundedAmount/refundedAt/stripeRefundId 記録）
- SHIPPED 以降は 403（CANNOT_CANCEL）
- 在庫復元・ステータス更新・監査ログを Prisma トランザクションで原子的に実行
- 楽観ロック（status一致条件）で競合検出（409）

## UI
- /orders/[id] にキャンセルボタンを追加（PENDING/PAID 時のみ）
- 確認ダイアログで PAID 時は返金案内を表示

## セキュリティ
- 他人の注文への操作は 404 で隠蔽（OWASP A01）
- AuditLog に ORDER_STATUS_CHANGE を cancelledByCustomer:true で記録