### PR TITLE
feat(account): 配送先アドレス帳 (#134)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model User {
   emailVerificationTokens EmailVerificationToken[] // 追加 (#120)
   auditLogs               AuditLog[] // 追加 (#121)
   passwordResetTokens     PasswordResetToken[] // 追加 (#129)
+  addresses               Address[] // 追加 (#134)
 
   @@map("users")
 }
@@ -130,6 +131,27 @@ model PasswordResetToken {
 
   @@index([userId])
   @@map("password_reset_tokens")
+}
+
+// 追加 (#134): 配送先アドレス帳
+model Address {
+  id            String   @id @default(cuid())
+  userId        String
+  name          String
+  postalCode    String
+  prefecture    String
+  city          String
+  addressLine1  String
+  addressLine2  String?
+  phone         String
+  isDefault     Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("addresses")
 }
 
 // ----- カテゴリ -----

--- a/src/app/(shop)/account/addresses/page.tsx
+++ b/src/app/(shop)/account/addresses/page.tsx
@@ -1,0 +1,48 @@
+// 配送先アドレス帳 ページ（#134）
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { auth } from '@/lib/auth'
+import { findAddressesByUserId } from '@/lib/db/addresses'
+import { AddressBookManager } from '@/components/features/account/AddressBookManager'
+
+export const metadata: Metadata = {
+  title: '配送先アドレス帳',
+}
+
+export default async function AddressBookPage() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect('/login?redirect=/account/addresses')
+  }
+
+  const addresses = await findAddressesByUserId(session.user.id)
+
+  // Date を ISO 文字列に変換してクライアントへ渡す
+  const items = addresses.map((a) => ({
+    id: a.id,
+    name: a.name,
+    postalCode: a.postalCode,
+    prefecture: a.prefecture,
+    city: a.city,
+    addressLine1: a.addressLine1,
+    addressLine2: a.addressLine2 ?? '',
+    phone: a.phone,
+    isDefault: a.isDefault,
+  }))
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <Link
+        href="/account"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+      >
+        <ArrowLeft size={14} aria-hidden="true" />
+        マイページに戻る
+      </Link>
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">配送先アドレス帳</h1>
+      <AddressBookManager initialAddresses={items} />
+    </main>
+  )
+}

--- a/src/app/(shop)/account/page.tsx
+++ b/src/app/(shop)/account/page.tsx
@@ -52,6 +52,22 @@ export default async function AccountPage() {
           </div>
         </section>
 
+        {/* 配送先アドレス帳へのリンク (#134) */}
+        <section aria-labelledby="addresses-link-heading">
+          <div className="flex items-center justify-between rounded-lg border bg-card p-6">
+            <div>
+              <h2 id="addresses-link-heading" className="font-semibold">配送先アドレス帳</h2>
+              <p className="text-sm text-muted-foreground mt-1">よく使う配送先を保存できます</p>
+            </div>
+            <Link
+              href="/account/addresses"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              管理する
+            </Link>
+          </div>
+        </section>
+
         {/* 最近の注文セクション */}
         <section aria-labelledby="recent-orders-heading">
           <div className="flex items-center justify-between mb-3">

--- a/src/app/api/account/addresses/[id]/route.ts
+++ b/src/app/api/account/addresses/[id]/route.ts
@@ -1,0 +1,66 @@
+// アドレス帳 API（#134）更新・削除
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import {
+  deleteAddress,
+  findAddressById,
+  updateAddress,
+} from '@/lib/db/addresses'
+import { addressInputSchema } from '@/lib/validators/address'
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+export const PATCH = async (req: NextRequest, { params }: RouteParams) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const { id } = await params
+  try {
+    const existing = await findAddressById(id)
+    // 他人のアドレスは 404 で隠蔽（OWASP A01）
+    if (!existing || existing.userId !== session.user.id) {
+      return NextResponse.json({ error: 'アドレスが見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    const body: unknown = await req.json()
+    const parsed = addressInputSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '入力内容が正しくありません', code: 'VALIDATION_ERROR', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+    const updated = await updateAddress(id, session.user.id, parsed.data)
+    return NextResponse.json({ address: updated })
+  } catch (err) {
+    console.error('[account/addresses/:id PATCH] エラー:', err)
+    return NextResponse.json(
+      { error: 'アドレス更新に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+export const DELETE = async (_req: NextRequest, { params }: RouteParams) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const { id } = await params
+  try {
+    const existing = await findAddressById(id)
+    if (!existing || existing.userId !== session.user.id) {
+      return NextResponse.json({ error: 'アドレスが見つかりません', code: 'NOT_FOUND' }, { status: 404 })
+    }
+    await deleteAddress(id)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('[account/addresses/:id DELETE] エラー:', err)
+    return NextResponse.json(
+      { error: 'アドレス削除に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/account/addresses/route.ts
+++ b/src/app/api/account/addresses/route.ts
@@ -1,0 +1,50 @@
+// アドレス帳 API（#134）一覧取得 + 新規作成
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import {
+  createAddress,
+  findAddressesByUserId,
+} from '@/lib/db/addresses'
+import { addressInputSchema } from '@/lib/validators/address'
+
+export const GET = async () => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  try {
+    const addresses = await findAddressesByUserId(session.user.id)
+    return NextResponse.json({ addresses })
+  } catch (err) {
+    console.error('[account/addresses GET] エラー:', err)
+    return NextResponse.json(
+      { error: 'アドレス取得に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}
+
+export const POST = async (req: NextRequest) => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: '認証が必要です', code: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  try {
+    const body: unknown = await req.json()
+    const parsed = addressInputSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: '入力内容が正しくありません', code: 'VALIDATION_ERROR', details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+    const created = await createAddress(session.user.id, parsed.data)
+    return NextResponse.json({ address: created }, { status: 201 })
+  } catch (err) {
+    console.error('[account/addresses POST] エラー:', err)
+    return NextResponse.json(
+      { error: 'アドレス作成に失敗しました', code: 'INTERNAL_SERVER_ERROR' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/features/account/AddressBookManager.tsx
+++ b/src/components/features/account/AddressBookManager.tsx
@@ -1,0 +1,331 @@
+'use client'
+
+// 配送先アドレス帳マネージャ（#134）
+// 一覧表示 + 追加 / 編集 / 削除 / デフォルト切替
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { addressInputSchema, type AddressInput } from '@/lib/validators/address'
+
+export type AddressItem = {
+  id: string
+  name: string
+  postalCode: string
+  prefecture: string
+  city: string
+  addressLine1: string
+  addressLine2: string
+  phone: string
+  isDefault: boolean
+}
+
+type Props = {
+  initialAddresses: AddressItem[]
+}
+
+export const AddressBookManager = ({ initialAddresses }: Props) => {
+  const router = useRouter()
+  const [addresses, setAddresses] = useState<AddressItem[]>(initialAddresses)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const editing = editingId ? addresses.find((a) => a.id === editingId) ?? null : null
+
+  const form = useForm<AddressInput>({
+    resolver: zodResolver(addressInputSchema),
+    defaultValues: {
+      name: '',
+      postalCode: '',
+      prefecture: '',
+      city: '',
+      addressLine1: '',
+      addressLine2: '',
+      phone: '',
+      isDefault: false,
+    },
+  })
+
+  const startCreate = () => {
+    setEditingId(null)
+    form.reset({
+      name: '',
+      postalCode: '',
+      prefecture: '',
+      city: '',
+      addressLine1: '',
+      addressLine2: '',
+      phone: '',
+      isDefault: addresses.length === 0,
+    })
+    setServerError(null)
+    setShowForm(true)
+  }
+
+  const startEdit = (a: AddressItem) => {
+    setEditingId(a.id)
+    form.reset({
+      name: a.name,
+      postalCode: a.postalCode,
+      prefecture: a.prefecture,
+      city: a.city,
+      addressLine1: a.addressLine1,
+      addressLine2: a.addressLine2,
+      phone: a.phone,
+      isDefault: a.isDefault,
+    })
+    setServerError(null)
+    setShowForm(true)
+  }
+
+  const cancelForm = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setServerError(null)
+  }
+
+  const onSubmit = async (data: AddressInput) => {
+    setServerError(null)
+    try {
+      const url = editingId
+        ? `/api/account/addresses/${editingId}`
+        : '/api/account/addresses'
+      const method = editingId ? 'PATCH' : 'POST'
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string }
+        setServerError(json.error ?? '保存に失敗しました')
+        return
+      }
+      setShowForm(false)
+      setEditingId(null)
+      router.refresh()
+      // ローカル状態の即時更新（サーバ情報で最終的に refresh される）
+      const json = (await res.json()) as { address: { id: string } & AddressInput }
+      const updated: AddressItem = {
+        id: json.address.id,
+        name: json.address.name,
+        postalCode: json.address.postalCode,
+        prefecture: json.address.prefecture,
+        city: json.address.city,
+        addressLine1: json.address.addressLine1,
+        addressLine2: json.address.addressLine2 ?? '',
+        phone: json.address.phone,
+        isDefault: Boolean(json.address.isDefault),
+      }
+      setAddresses((prev) => {
+        const next = editingId
+          ? prev.map((a) => (a.id === editingId ? updated : a))
+          : [...prev, updated]
+        if (updated.isDefault) {
+          return next.map((a) =>
+            a.id === updated.id ? a : { ...a, isDefault: false },
+          )
+        }
+        return next
+      })
+    } catch {
+      setServerError('通信エラーが発生しました')
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('このアドレスを削除しますか？')) return
+    try {
+      const res = await fetch(`/api/account/addresses/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string }
+        setServerError(json.error ?? '削除に失敗しました')
+        return
+      }
+      setAddresses((prev) => prev.filter((a) => a.id !== id))
+      router.refresh()
+    } catch {
+      setServerError('通信エラーが発生しました')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 一覧 */}
+      {addresses.length === 0 && !showForm ? (
+        <div className="rounded-lg border bg-card p-8 text-center">
+          <p className="text-sm text-muted-foreground mb-4">
+            登録されたアドレスはありません。
+          </p>
+          <Button type="button" onClick={startCreate}>
+            アドレスを追加
+          </Button>
+        </div>
+      ) : (
+        <>
+          <ul className="space-y-3">
+            {addresses.map((a) => (
+              <li key={a.id} className="rounded-lg border bg-card p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1 text-sm">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{a.name}</span>
+                      {a.isDefault && (
+                        <span className="rounded-full bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground">
+                          デフォルト
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-muted-foreground">
+                      〒{a.postalCode} {a.prefecture}
+                      {a.city}
+                    </p>
+                    <p className="text-muted-foreground">{a.addressLine1}</p>
+                    {a.addressLine2 && (
+                      <p className="text-muted-foreground">{a.addressLine2}</p>
+                    )}
+                    <p className="text-muted-foreground">TEL: {a.phone}</p>
+                  </div>
+                  <div className="flex shrink-0 flex-col gap-1">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => startEdit(a)}
+                    >
+                      編集
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => handleDelete(a.id)}
+                    >
+                      削除
+                    </Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+          {!showForm && (
+            <Button type="button" onClick={startCreate}>
+              アドレスを追加
+            </Button>
+          )}
+        </>
+      )}
+
+      {/* フォーム */}
+      {showForm && (
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          noValidate
+          className="rounded-lg border bg-card p-6 space-y-4"
+        >
+          <h2 className="font-semibold">
+            {editing ? 'アドレスを編集' : 'アドレスを追加'}
+          </h2>
+
+          <div className="space-y-2">
+            <Label htmlFor="name">お名前</Label>
+            <Input id="name" {...form.register('name')} />
+            {form.formState.errors.name && (
+              <p className="text-sm text-destructive" role="alert">
+                {form.formState.errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="postalCode">郵便番号</Label>
+              <Input
+                id="postalCode"
+                {...form.register('postalCode')}
+                autoComplete="postal-code"
+              />
+              {form.formState.errors.postalCode && (
+                <p className="text-sm text-destructive" role="alert">
+                  {form.formState.errors.postalCode.message}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="prefecture">都道府県</Label>
+              <Input id="prefecture" {...form.register('prefecture')} />
+              {form.formState.errors.prefecture && (
+                <p className="text-sm text-destructive" role="alert">
+                  {form.formState.errors.prefecture.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="city">市区町村</Label>
+            <Input id="city" {...form.register('city')} />
+            {form.formState.errors.city && (
+              <p className="text-sm text-destructive" role="alert">
+                {form.formState.errors.city.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="addressLine1">番地</Label>
+            <Input id="addressLine1" {...form.register('addressLine1')} />
+            {form.formState.errors.addressLine1 && (
+              <p className="text-sm text-destructive" role="alert">
+                {form.formState.errors.addressLine1.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="addressLine2">建物名・部屋番号（任意）</Label>
+            <Input id="addressLine2" {...form.register('addressLine2')} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="phone">電話番号</Label>
+            <Input id="phone" type="tel" {...form.register('phone')} />
+            {form.formState.errors.phone && (
+              <p className="text-sm text-destructive" role="alert">
+                {form.formState.errors.phone.message}
+              </p>
+            )}
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              {...form.register('isDefault')}
+              className="h-4 w-4 rounded border-border"
+            />
+            デフォルトの配送先にする
+          </label>
+
+          {serverError && (
+            <p className="text-sm text-destructive" role="alert">
+              {serverError}
+            </p>
+          )}
+
+          <div className="flex gap-2">
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? '保存中...' : '保存'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={cancelForm}>
+              キャンセル
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/checkout/CheckoutForm.tsx
+++ b/src/components/features/checkout/CheckoutForm.tsx
@@ -7,7 +7,7 @@ import {
   useStripe,
 } from '@stripe/react-stripe-js'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { CHECKOUT_SUCCESS_PATH } from '@/constants/checkout'
@@ -26,6 +26,19 @@ const shippingSchema = z.object({
 })
 
 type ShippingFormValues = z.infer<typeof shippingSchema>
+
+// 追加 (#134): 保存済みアドレス型（API レスポンス用、最低限のフィールドのみ）
+type SavedAddress = {
+  id: string
+  name: string
+  postalCode: string
+  prefecture: string
+  city: string
+  addressLine1: string
+  addressLine2: string | null
+  phone: string
+  isDefault: boolean
+}
 
 // 適用済みクーポン型 // 追加
 type AppliedCoupon = {
@@ -52,10 +65,59 @@ export const CheckoutForm = ({ clientSecret, paymentIntentId, appliedCoupon, onC
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<ShippingFormValues>({
     resolver: zodResolver(shippingSchema),
   })
+
+  // 追加 (#134): 保存済みアドレスを取得し、デフォルトがあれば自動入力
+  const [savedAddresses, setSavedAddresses] = useState<SavedAddress[]>([])
+  const [selectedAddressId, setSelectedAddressId] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await fetch('/api/account/addresses')
+        if (!res.ok) return
+        const json = (await res.json()) as { addresses?: SavedAddress[] }
+        if (cancelled || !json.addresses) return
+        setSavedAddresses(json.addresses)
+        const def = json.addresses.find((a) => a.isDefault)
+        if (def) {
+          setSelectedAddressId(def.id)
+          applyAddress(def)
+        }
+      } catch {
+        // 認証されていない場合などは無視
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const applyAddress = (a: SavedAddress) => {
+    // 郵便番号は登録時にハイフン許容、決済時は7桁数字必須なのでハイフン除去して入れる
+    const normalizedPostal = a.postalCode.replace(/[^\d]/g, '')
+    setValue('name', a.name, { shouldValidate: true })
+    setValue('phone', a.phone, { shouldValidate: true })
+    setValue('postalCode', normalizedPostal, { shouldValidate: true })
+    setValue('prefecture', a.prefecture, { shouldValidate: true })
+    setValue('city', a.city, { shouldValidate: true })
+    setValue('addressLine1', a.addressLine1, { shouldValidate: true })
+    setValue('addressLine2', a.addressLine2 ?? '', { shouldValidate: true })
+  }
+
+  const onSelectAddress = (id: string) => {
+    setSelectedAddressId(id)
+    if (!id) return
+    const a = savedAddresses.find((x) => x.id === id)
+    if (a) applyAddress(a)
+  }
 
   const onSubmit = async (data: ShippingFormValues) => {
     if (!stripeInstance || !elements) return
@@ -121,6 +183,31 @@ export const CheckoutForm = ({ clientSecret, paymentIntentId, appliedCoupon, onC
         <h2 id="shipping-heading" className="mb-4 text-lg font-semibold">
           配送先情報
         </h2>
+
+        {/* 保存済みアドレスの選択 (#134) */}
+        {savedAddresses.length > 0 && (
+          <div className="mb-4 rounded-md border bg-muted/30 p-3">
+            <label htmlFor="saved-address" className="block text-sm font-medium mb-1">
+              保存済みアドレスから選択
+            </label>
+            <select
+              id="saved-address"
+              value={selectedAddressId}
+              onChange={(e) => onSelectAddress(e.target.value)}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              <option value="">選択してください</option>
+              {savedAddresses.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name} - 〒{a.postalCode} {a.prefecture}
+                  {a.city}
+                  {a.isDefault ? '（デフォルト）' : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
         <div className="space-y-4">
           {/* お名前 */}
           <div className="space-y-1">

--- a/src/lib/db/addresses.ts
+++ b/src/lib/db/addresses.ts
@@ -1,0 +1,77 @@
+// アドレス帳 DB 操作（#134）
+import { prisma } from '@/lib/db/prisma'
+import type { AddressInput } from '@/lib/validators/address'
+
+// ユーザーのアドレス一覧（デフォルト → 新しい順）
+export const findAddressesByUserId = async (userId: string) => {
+  return prisma.address.findMany({
+    where: { userId },
+    orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+  })
+}
+
+// ID 指定で取得
+export const findAddressById = async (id: string) => {
+  return prisma.address.findUnique({ where: { id } })
+}
+
+// 新規作成（isDefault=true ならトランザクションで他をfalseに）
+export const createAddress = async (userId: string, input: AddressInput) => {
+  const isDefault = Boolean(input.isDefault)
+  return prisma.$transaction(async (tx) => {
+    if (isDefault) {
+      await tx.address.updateMany({
+        where: { userId, isDefault: true },
+        data: { isDefault: false },
+      })
+    }
+    return tx.address.create({
+      data: {
+        userId,
+        name: input.name,
+        postalCode: input.postalCode,
+        prefecture: input.prefecture,
+        city: input.city,
+        addressLine1: input.addressLine1,
+        addressLine2: input.addressLine2 ?? null,
+        phone: input.phone,
+        isDefault,
+      },
+    })
+  })
+}
+
+// 更新（isDefault=true ならトランザクションで他をfalseに）
+export const updateAddress = async (
+  id: string,
+  userId: string,
+  input: AddressInput,
+) => {
+  const isDefault = Boolean(input.isDefault)
+  return prisma.$transaction(async (tx) => {
+    if (isDefault) {
+      await tx.address.updateMany({
+        where: { userId, isDefault: true, NOT: { id } },
+        data: { isDefault: false },
+      })
+    }
+    return tx.address.update({
+      where: { id },
+      data: {
+        name: input.name,
+        postalCode: input.postalCode,
+        prefecture: input.prefecture,
+        city: input.city,
+        addressLine1: input.addressLine1,
+        addressLine2: input.addressLine2 ?? null,
+        phone: input.phone,
+        isDefault,
+      },
+    })
+  })
+}
+
+// 削除
+export const deleteAddress = async (id: string) => {
+  return prisma.address.delete({ where: { id } })
+}

--- a/src/lib/validators/address.test.ts
+++ b/src/lib/validators/address.test.ts
@@ -1,0 +1,50 @@
+// アドレス帳バリデータのテスト（#134）
+import { describe, expect, it } from 'vitest'
+import { addressInputSchema } from './address'
+
+const valid = {
+  name: '山田太郎',
+  postalCode: '100-0001',
+  prefecture: '東京都',
+  city: '千代田区',
+  addressLine1: '1-1-1',
+  addressLine2: '○○ビル101',
+  phone: '03-1234-5678',
+  isDefault: true,
+}
+
+describe('addressInputSchema', () => {
+  it('有効な入力を受理する', () => {
+    expect(addressInputSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('addressLine2 を省略可能', () => {
+    const { addressLine2: _omit, ...rest } = valid
+    void _omit
+    expect(addressInputSchema.safeParse(rest).success).toBe(true)
+  })
+
+  it('addressLine2 が空文字の場合は undefined に変換される', () => {
+    const result = addressInputSchema.safeParse({ ...valid, addressLine2: '' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.addressLine2).toBeUndefined()
+    }
+  })
+
+  it('郵便番号がハイフンなしでも受理する', () => {
+    expect(
+      addressInputSchema.safeParse({ ...valid, postalCode: '1000001' }).success,
+    ).toBe(true)
+  })
+
+  it('電話番号に英字を含むと拒否する', () => {
+    expect(
+      addressInputSchema.safeParse({ ...valid, phone: 'abc-1234' }).success,
+    ).toBe(false)
+  })
+
+  it('name が空だと拒否する', () => {
+    expect(addressInputSchema.safeParse({ ...valid, name: '' }).success).toBe(false)
+  })
+})

--- a/src/lib/validators/address.ts
+++ b/src/lib/validators/address.ts
@@ -1,0 +1,41 @@
+// 配送先アドレス帳の Zod バリデーションスキーマ（#134）
+import { z } from 'zod'
+
+// 入力スキーマ（POST/PATCH 共通の本体）
+export const addressInputSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'お名前を入力してください')
+    .max(100, 'お名前は100文字以内で入力してください'),
+  postalCode: z
+    .string()
+    .min(1, '郵便番号を入力してください')
+    .max(10, '郵便番号の形式が正しくありません')
+    .regex(/^[0-9-]+$/, '郵便番号は数字とハイフンで入力してください'),
+  prefecture: z
+    .string()
+    .min(1, '都道府県を入力してください')
+    .max(20, '都道府県は20文字以内で入力してください'),
+  city: z
+    .string()
+    .min(1, '市区町村を入力してください')
+    .max(100, '市区町村は100文字以内で入力してください'),
+  addressLine1: z
+    .string()
+    .min(1, '番地を入力してください')
+    .max(200, '住所1は200文字以内で入力してください'),
+  addressLine2: z
+    .union([
+      z.literal('').transform(() => undefined),
+      z.string().max(200, '住所2は200文字以内で入力してください'),
+    ])
+    .optional(),
+  phone: z
+    .string()
+    .min(1, '電話番号を入力してください')
+    .max(20, '電話番号の形式が正しくありません')
+    .regex(/^[0-9-+() ]+$/, '電話番号の形式が正しくありません'),
+  isDefault: z.boolean().optional(),
+})
+
+export type AddressInput = z.infer<typeof addressInputSchema>


### PR DESCRIPTION
Closes #134

## 概要
顧客がよく使う配送先を保存・管理できるアドレス帳機能を追加。チェックアウトでも保存済みアドレスを選択可能に。

## 変更点
- `Address` モデル追加（userId/name/postalCode/prefecture/city/addressLine1/addressLine2?/phone/isDefault）
- API:
  - GET /api/account/addresses（自身のみ）
  - POST /api/account/addresses（新規作成、isDefault トランザクション処理）
  - PATCH /api/account/addresses/[id]（更新）
  - DELETE /api/account/addresses/[id]（削除）
- ページ: /account/addresses（一覧 / 追加 / 編集 / 削除 / デフォルト切替）
- マイページにアドレス帳へのリンクを追加
- チェックアウトで保存済みアドレスを選択するセレクター追加（デフォルトを自動入力）
- Zod バリデータと単体テスト

## セキュリティ
- 全ての操作で本人確認（404 で他人のアドレスを隠蔽 - OWASP A01）
- isDefault の整合性をトランザクションで保証
- ユーザー削除時は onDelete: Cascade